### PR TITLE
Adds example event summary json file 

### DIFF
--- a/etc/event.json
+++ b/etc/event.json
@@ -12,72 +12,84 @@
     "magnitudeType": "Ms_20",
     "magnitudes": [
       {
+        "id": "50003UWR/ml_module/NEIC/ML"
         "author": "ml_module",
         "installation": "NEIC",
         "type": "ML",
         "value": 5.311
       },
       {
+        "id": "50003UWR/Event_validation/NEIC/Mqa"
         "author": "Event_validation",
         "installation": "NEIC",
         "type": "Mqa",
         "value": 4.63
       },
       {
+        "id": "50003UWR/determine_prefmag_module/NEIC/M"
         "author": "determine_prefmag_module",
         "installation": "NEIC",
         "type": "M",
         "value": 5.705
       },
       {
+        "id": "50003UWR/mblg_module/NEIC/Mb_Lg"
         "author": "mblg_module",
         "installation": "NEIC",
         "type": "Mb_Lg",
         "value": 5.134
       },
       {
+        "id": "50003UWR/compositeMT_module/NEIC/Mwcm"
         "author": "compositeMT_module",
         "installation": "NEIC",
         "type": "Mwcm",
         "value": 5.933
       },
       {
+        "id": "50003UWR/mwp_module/NEIC/Mwp"
         "author": "mwp_module",
         "installation": "NEIC",
         "type": "Mwp",
         "value": 5.822
       },
       {
+        "id": "50003UWR/mb_module/NEIC/mb"
         "author": "mb_module",
         "installation": "NEIC",
         "type": "mb",
         "value": 5.548
       },
       {
+        "id": "50003UWR/rmt_module/NEIC/Mwr"
         "author": "rmt_module",
         "installation": "NEIC",
         "type": "Mwr",
         "value": 5.584
       },
       {
+        "id": "50003UWR/md_module/NEIC/Md"
         "author": "md_module",
         "installation": "NEIC",
         "type": "Md",
         "value": 5.043
       },
       {
+        "id": "50003UWR/wphase_module/NEIC/Mww"
         "author": "wphase_module",
         "installation": "NEIC",
         "type": "Mww",
         "value": 5.768
       },
       {
+        "id": "50003UWR/mt_module/NEIC/Mwb"
         "author": "mt_module",
         "installation": "NEIC",
         "type": "Mwb",
         "value": 5.707
       },
       {
+        "id": "50003UWR/ms_module/NEIC/Ms_20"
         "author": "ms_module",
         "installation": "NEIC",
         "type": "Ms_20",

--- a/etc/event.json
+++ b/etc/event.json
@@ -1,0 +1,91 @@
+{
+  "id": "50003UWR",
+  "geometry": {
+    "coordinates": [
+      -30.171801, -72.155899, 5.14
+    ],
+    "type": "Point"
+  },
+  "properties": {
+    "eventtime": "2016-07-19T05:18:38.58Z",
+    "magnitude": 5.224,
+    "magnitudeType": "Ms_20",
+    "magnitudes": [
+      {
+        "author": "ml_module",
+        "installation": "NEIC",
+        "type": "ML",
+        "value": 5.311
+      },
+      {
+        "author": "Event_validation",
+        "installation": "NEIC",
+        "type": "Mqa",
+        "value": 4.63
+      },
+      {
+        "author": "determine_prefmag_module",
+        "installation": "NEIC",
+        "type": "M",
+        "value": 5.705
+      },
+      {
+        "author": "mblg_module",
+        "installation": "NEIC",
+        "type": "Mb_Lg",
+        "value": 5.134
+      },
+      {
+        "author": "compositeMT_module",
+        "installation": "NEIC",
+        "type": "Mwcm",
+        "value": 5.933
+      },
+      {
+        "author": "mwp_module",
+        "installation": "NEIC",
+        "type": "Mwp",
+        "value": 5.822
+      },
+      {
+        "author": "mb_module",
+        "installation": "NEIC",
+        "type": "mb",
+        "value": 5.548
+      },
+      {
+        "author": "rmt_module",
+        "installation": "NEIC",
+        "type": "Mwr",
+        "value": 5.584
+      },
+      {
+        "author": "md_module",
+        "installation": "NEIC",
+        "type": "Md",
+        "value": 5.043
+      },
+      {
+        "author": "wphase_module",
+        "installation": "NEIC",
+        "type": "Mww",
+        "value": 5.768
+      },
+      {
+        "author": "mt_module",
+        "installation": "NEIC",
+        "type": "Mwb",
+        "value": 5.707
+      },
+      {
+        "author": "ms_module",
+        "installation": "NEIC",
+        "type": "Ms_20",
+        "value": 5.224
+      }
+    ],
+    "title": "OFFSHORE COQUIMBO, CHILE",
+    "type": "Earthquake"
+  },
+  "type": "Feature"
+}

--- a/etc/event.json
+++ b/etc/event.json
@@ -1,5 +1,5 @@
 {
-  "id": "50003UWR",
+  "id": "50003uwr",
   "geometry": {
     "coordinates": [
       -30.171801, -72.155899, 5.14
@@ -12,84 +12,84 @@
     "magnitudeType": "Ms_20",
     "magnitudes": [
       {
-        "id": "50003UWR/ml_module/NEIC/ML",
+        "id": "50003uwr/ml_module/neic/ml",
         "author": "ml_module",
         "installation": "NEIC",
         "type": "ML",
         "value": 5.311
       },
       {
-        "id": "50003UWR/Event_validation/NEIC/Mqa",
+        "id": "50003uwr/event_validation/neic/mqa",
         "author": "Event_validation",
         "installation": "NEIC",
         "type": "Mqa",
         "value": 4.63
       },
       {
-        "id": "50003UWR/determine_prefmag_module/NEIC/M",
+        "id": "50003uwr/determine_prefmag_module/neic/m",
         "author": "determine_prefmag_module",
         "installation": "NEIC",
         "type": "M",
         "value": 5.705
       },
       {
-        "id": "50003UWR/mblg_module/NEIC/Mb_Lg",
+        "id": "50003uwr/mblg_module/neic/mb_lg",
         "author": "mblg_module",
         "installation": "NEIC",
         "type": "Mb_Lg",
         "value": 5.134
       },
       {
-        "id": "50003UWR/compositeMT_module/NEIC/Mwcm",
+        "id": "50003uwr/compositemt_module/neic/mwcm",
         "author": "compositeMT_module",
         "installation": "NEIC",
         "type": "Mwcm",
         "value": 5.933
       },
       {
-        "id": "50003UWR/mwp_module/NEIC/Mwp",
+        "id": "50003uwr/mwp_module/neic/mwp",
         "author": "mwp_module",
         "installation": "NEIC",
         "type": "Mwp",
         "value": 5.822
       },
       {
-        "id": "50003UWR/mb_module/NEIC/mb",
+        "id": "50003uwr/mb_module/neic/mb",
         "author": "mb_module",
         "installation": "NEIC",
         "type": "mb",
         "value": 5.548
       },
       {
-        "id": "50003UWR/rmt_module/NEIC/Mwr",
+        "id": "50003uwr/rmt_module/neic/mwr",
         "author": "rmt_module",
         "installation": "NEIC",
         "type": "Mwr",
         "value": 5.584
       },
       {
-        "id": "50003UWR/md_module/NEIC/Md",
+        "id": "50003uwr/md_module/neic/md",
         "author": "md_module",
         "installation": "NEIC",
         "type": "Md",
         "value": 5.043
       },
       {
-        "id": "50003UWR/wphase_module/NEIC/Mww",
+        "id": "50003uwr/wphase_module/neic/mww",
         "author": "wphase_module",
         "installation": "NEIC",
         "type": "Mww",
         "value": 5.768
       },
       {
-        "id": "50003UWR/mt_module/NEIC/Mwb",
+        "id": "50003uwr/mt_module/neic/mwb",
         "author": "mt_module",
         "installation": "NEIC",
         "type": "Mwb",
         "value": 5.707
       },
       {
-        "id": "50003UWR/ms_module/NEIC/Ms_20",
+        "id": "50003uwr/ms_module/neic/ms_20",
         "author": "ms_module",
         "installation": "NEIC",
         "type": "Ms_20",

--- a/etc/event.json
+++ b/etc/event.json
@@ -12,84 +12,84 @@
     "magnitudeType": "Ms_20",
     "magnitudes": [
       {
-        "id": "50003UWR/ml_module/NEIC/ML"
+        "id": "50003UWR/ml_module/NEIC/ML",
         "author": "ml_module",
         "installation": "NEIC",
         "type": "ML",
         "value": 5.311
       },
       {
-        "id": "50003UWR/Event_validation/NEIC/Mqa"
+        "id": "50003UWR/Event_validation/NEIC/Mqa",
         "author": "Event_validation",
         "installation": "NEIC",
         "type": "Mqa",
         "value": 4.63
       },
       {
-        "id": "50003UWR/determine_prefmag_module/NEIC/M"
+        "id": "50003UWR/determine_prefmag_module/NEIC/M",
         "author": "determine_prefmag_module",
         "installation": "NEIC",
         "type": "M",
         "value": 5.705
       },
       {
-        "id": "50003UWR/mblg_module/NEIC/Mb_Lg"
+        "id": "50003UWR/mblg_module/NEIC/Mb_Lg",
         "author": "mblg_module",
         "installation": "NEIC",
         "type": "Mb_Lg",
         "value": 5.134
       },
       {
-        "id": "50003UWR/compositeMT_module/NEIC/Mwcm"
+        "id": "50003UWR/compositeMT_module/NEIC/Mwcm",
         "author": "compositeMT_module",
         "installation": "NEIC",
         "type": "Mwcm",
         "value": 5.933
       },
       {
-        "id": "50003UWR/mwp_module/NEIC/Mwp"
+        "id": "50003UWR/mwp_module/NEIC/Mwp",
         "author": "mwp_module",
         "installation": "NEIC",
         "type": "Mwp",
         "value": 5.822
       },
       {
-        "id": "50003UWR/mb_module/NEIC/mb"
+        "id": "50003UWR/mb_module/NEIC/mb",
         "author": "mb_module",
         "installation": "NEIC",
         "type": "mb",
         "value": 5.548
       },
       {
-        "id": "50003UWR/rmt_module/NEIC/Mwr"
+        "id": "50003UWR/rmt_module/NEIC/Mwr",
         "author": "rmt_module",
         "installation": "NEIC",
         "type": "Mwr",
         "value": 5.584
       },
       {
-        "id": "50003UWR/md_module/NEIC/Md"
+        "id": "50003UWR/md_module/NEIC/Md",
         "author": "md_module",
         "installation": "NEIC",
         "type": "Md",
         "value": 5.043
       },
       {
-        "id": "50003UWR/wphase_module/NEIC/Mww"
+        "id": "50003UWR/wphase_module/NEIC/Mww",
         "author": "wphase_module",
         "installation": "NEIC",
         "type": "Mww",
         "value": 5.768
       },
       {
-        "id": "50003UWR/mt_module/NEIC/Mwb"
+        "id": "50003UWR/mt_module/NEIC/Mwb",
         "author": "mt_module",
         "installation": "NEIC",
         "type": "Mwb",
         "value": 5.707
       },
       {
-        "id": "50003UWR/ms_module/NEIC/Ms_20"
+        "id": "50003UWR/ms_module/NEIC/Ms_20",
         "author": "ms_module",
         "installation": "NEIC",
         "type": "Ms_20",

--- a/etc/event.json
+++ b/etc/event.json
@@ -1,5 +1,5 @@
 {
-  "id": "50003uwr",
+  "id": "50003UWR",
   "geometry": {
     "coordinates": [
       -30.171801, -72.155899, 5.14
@@ -12,84 +12,84 @@
     "magnitudeType": "Ms_20",
     "magnitudes": [
       {
-        "id": "50003uwr/ml_module/neic/ml",
+        "id": "50003UWR/ml_module/NEIC/ML",
         "author": "ml_module",
         "installation": "NEIC",
         "type": "ML",
         "value": 5.311
       },
       {
-        "id": "50003uwr/event_validation/neic/mqa",
+        "id": "50003UWR/Event_validation/NEIC/Mqa",
         "author": "Event_validation",
         "installation": "NEIC",
         "type": "Mqa",
         "value": 4.63
       },
       {
-        "id": "50003uwr/determine_prefmag_module/neic/m",
+        "id": "50003UWR/determine_prefmag_module/NEIC/M",
         "author": "determine_prefmag_module",
         "installation": "NEIC",
         "type": "M",
         "value": 5.705
       },
       {
-        "id": "50003uwr/mblg_module/neic/mb_lg",
+        "id": "50003UWR/mblg_module/NEIC/Mb_Lg",
         "author": "mblg_module",
         "installation": "NEIC",
         "type": "Mb_Lg",
         "value": 5.134
       },
       {
-        "id": "50003uwr/compositemt_module/neic/mwcm",
+        "id": "50003UWR/compositeMT_module/NEIC/Mwcm",
         "author": "compositeMT_module",
         "installation": "NEIC",
         "type": "Mwcm",
         "value": 5.933
       },
       {
-        "id": "50003uwr/mwp_module/neic/mwp",
+        "id": "50003UWR/mwp_module/NEIC/Mwp",
         "author": "mwp_module",
         "installation": "NEIC",
         "type": "Mwp",
         "value": 5.822
       },
       {
-        "id": "50003uwr/mb_module/neic/mb",
+        "id": "50003UWR/mb_module/NEIC/mb",
         "author": "mb_module",
         "installation": "NEIC",
         "type": "mb",
         "value": 5.548
       },
       {
-        "id": "50003uwr/rmt_module/neic/mwr",
+        "id": "50003UWR/rmt_module/NEIC/Mwr",
         "author": "rmt_module",
         "installation": "NEIC",
         "type": "Mwr",
         "value": 5.584
       },
       {
-        "id": "50003uwr/md_module/neic/md",
+        "id": "50003UWR/md_module/NEIC/Md",
         "author": "md_module",
         "installation": "NEIC",
         "type": "Md",
         "value": 5.043
       },
       {
-        "id": "50003uwr/wphase_module/neic/mww",
+        "id": "50003UWR/wphase_module/NEIC/Mww",
         "author": "wphase_module",
         "installation": "NEIC",
         "type": "Mww",
         "value": 5.768
       },
       {
-        "id": "50003uwr/mt_module/neic/mwb",
+        "id": "50003UWR/mt_module/NEIC/Mwb",
         "author": "mt_module",
         "installation": "NEIC",
         "type": "Mwb",
         "value": 5.707
       },
       {
-        "id": "50003uwr/ms_module/neic/ms_20",
+        "id": "50003UWR/ms_module/NEIC/Ms_20",
         "author": "ms_module",
         "installation": "NEIC",
         "type": "Ms_20",


### PR DESCRIPTION
Created an example event summary file, using data from an existing event on hydra-black.
* Added id property as discussed. 
* Used the huid/author/installation/type format for ids because author names contain '_'
* Fixes #1 