### PR TITLE
Issue-5

### DIFF
--- a/example/MagnitudeSummaryViewExample.js
+++ b/example/MagnitudeSummaryViewExample.js
@@ -1,16 +1,36 @@
 'use strict';
 
-var MagnitudeSummaryView = require('MagnitudeSummaryView'),
+var Collection = require('mvc/Collection'),
+    MagnitudeSummaryView = require('MagnitudeSummaryView'),
     Model = require('mvc/Model'),
     Xhr = require('util/Xhr');
 
 Xhr.ajax({
-  url: 'event.json',
+  url: 'magnitude.json',
   success: function (data) {
-    var magnitudeCollectionView;
+    var magnitudeCollectionView,
+        magnitudes;
+
+    magnitudes = [
+      Model({
+        'id': '50003UWR/wphase_module/NEIC/Mww',
+        'author': 'wphase_module',
+        'installation': 'NEIC',
+        'type': 'Mww',
+        'value': 5.768
+      }),
+      Model({
+        'id': '50003UWR/author/installation/Mqa',
+        'author': 'author',
+        'installation': 'installation',
+        'type': 'Mww',
+        'value': 5.012
+      }),
+    ];
 
     magnitudeCollectionView = MagnitudeSummaryView({
       el: document.querySelector('#magnitude-summary-view-example'),
+      collection: Collection(magnitudes),
       model: Model(data)
     });
     magnitudeCollectionView.render();

--- a/example/MagnitudeSummaryViewExample.js
+++ b/example/MagnitudeSummaryViewExample.js
@@ -8,32 +8,43 @@ var Collection = require('mvc/Collection'),
 Xhr.ajax({
   url: 'magnitude.json',
   success: function (data) {
-    var magnitudeCollectionView,
-        magnitudes;
+    var magnitudeSummaryView;
 
-    magnitudes = [
-      Model({
-        'id': '50003UWR/wphase_module/NEIC/Mww',
-        'author': 'wphase_module',
-        'installation': 'NEIC',
-        'type': 'Mww',
-        'value': 5.768
-      }),
-      Model({
-        'id': '50003UWR/author/installation/Mqa',
-        'author': 'author',
-        'installation': 'installation',
-        'type': 'Mww',
-        'value': 5.012
-      }),
-    ];
-
-    magnitudeCollectionView = MagnitudeSummaryView({
+    magnitudeSummaryView = MagnitudeSummaryView({
       el: document.querySelector('#magnitude-summary-view-example'),
-      collection: Collection(magnitudes),
+      collection: Collection([
+        Model({
+          'id': '50003UWR/wphase_module/NEIC/Mww',
+          'author': 'wphase_module',
+          'installation': 'NEIC',
+          'type': 'Mww',
+          'value': 5.768
+        }),
+        Model({
+          'id': '50003UWR/author/installation/Mqa',
+          'author': 'author',
+          'installation': 'installation',
+          'type': 'Mww',
+          'value': 5.012
+        })
+      ]),
+      ev: Model({
+        'id': '50003UWR',
+        'geometry': {
+          'coordinates': [
+            -30.171801, -72.155899, 5.14
+          ],
+          'type': 'Point'
+        },
+        'eventtime': '2016-07-19T05:18:38.58Z',
+        'magnitude': 5.224,
+        'magnitudeType': 'Ms_20',
+        'title': 'OFFSHORE COQUIMBO, CHILE',
+        'type': 'Earthquake'
+      }),
       model: Model(data)
     });
-    magnitudeCollectionView.render();
+    magnitudeSummaryView.render();
 
   },
   error: function (e) {

--- a/example/MagnitudeSummaryViewExample.js
+++ b/example/MagnitudeSummaryViewExample.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var Collection = require('mvc/Collection'),
-    EventModel = require('EventModel'),
+var EventModel = require('EventModel'),
     MagnitudeModel = require('MagnitudeModel'),
     MagnitudeSummaryView = require('MagnitudeSummaryView'),
     Xhr = require('util/Xhr');
@@ -36,10 +35,12 @@ _initialize = function () {
     } else {
       // ... go ...
       view = MagnitudeSummaryView({
-        collection: Collection(eventModel.get('magnitudes').slice(0)),
         el: el,
+        event: eventModel,
         model: magnitudeModel
       });
+
+      view.render();
     }
   }
 };

--- a/example/MagnitudeSummaryViewExample.js
+++ b/example/MagnitudeSummaryViewExample.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var MagnitudeSummaryView = require('MagnitudeSummaryView'),
+    Model = require('mvc/Model'),
+    Xhr = require('util/Xhr');
+
+Xhr.ajax({
+  url: 'event.json',
+  success: function (data) {
+    var magnitudeCollectionView;
+
+    magnitudeCollectionView = MagnitudeSummaryView({
+      el: document.querySelector('#magnitude-summary-view-example'),
+      model: Model(data)
+    });
+    magnitudeCollectionView.render();
+
+  },
+  error: function (e) {
+    console.log(e);
+    document.querySelector('#magnitude-summary-view-example').innerHTML = [
+      '<p class="alert error">',
+        'Failed to create a Magnitude Summary View.',
+      '</p>'
+    ].join('');
+  }
+});

--- a/example/MagnitudeSummaryViewExample.php
+++ b/example/MagnitudeSummaryViewExample.php
@@ -1,0 +1,25 @@
+<?php
+if (!isset($TEMPLATE)) {
+
+  $TITLE = 'MagnitudeSummaryView Example';
+
+  // If you want to include section navigation.
+  // The nearest _navigation.inc.php file will be used by default
+  $NAVIGATION = true;
+
+  // Stuff that goes at the top of the page (in the <head>) (i.e. <link> tags)
+  $HEAD = '
+    <link rel="stylesheet" href="/css/magnitude.css"/>
+  ';
+
+  // Stuff that goes at the bottom of the page (i.e. <script> tags)
+  $FOOT = '
+    <script src="/js/bundle.js"></script>
+    <script src="MagnitudeSummaryViewExample.js"></script>
+  ';
+
+  include 'template.inc.php';
+}
+?>
+
+<div id="magnitude-summary-view-example"></div>

--- a/example/_navigation.inc.php
+++ b/example/_navigation.inc.php
@@ -9,8 +9,7 @@ print navGroup('Event',
 print navGroup('Magnitude',
     navItem('/MagnitudeCollectionTableExample.php',
         'MagnitudeCollectionTable') .
-    navItem('/MagnitudeSummaryViewExample.php',
-        'MagnitudeSummaryView') .
+    navItem('/MagnitudeSummaryViewExample.php', 'MagnitudeSummaryView') .
     navItem('MagnitudeTabViewExample.php', 'MagnitudeTabView')
   );
 

--- a/example/_navigation.inc.php
+++ b/example/_navigation.inc.php
@@ -6,9 +6,12 @@ print navGroup('Event',
     navItem('/EventSummaryViewExample.php', 'EventSummaryView')
   );
 
-print navGroup('magnitude',
-  navItem('/MagnitudeCollectionTableExample.php', 'MagnitudeCollectionTable') .
-  navItem('MagnitudeTabViewExample.php', 'MagnitudeTabView')
-);
+print navGroup('Magnitude',
+    navItem('/MagnitudeCollectionTableExample.php',
+        'MagnitudeCollectionTable') .
+    navItem('/MagnitudeSummaryViewExample.php',
+        'MagnitudeSummaryView') .
+    navItem('MagnitudeTabViewExample.php', 'MagnitudeTabView')
+  );
 
 ?>

--- a/gruntconfig/browserify.js
+++ b/gruntconfig/browserify.js
@@ -6,15 +6,7 @@ var babelify = require('babelify'),
     glob = require('glob');
 
 
-var BUNDLE_CLASSES,
-    CWD,
-    JS,
-    NODE_MODULES;
-
-
-CWD = process.cwd();
-NODE_MODULES = CWD + '/node_modules';
-JS = './' + config.src + '/htdocs/js';
+var BUNDLE_CLASSES;
 
 BUNDLE_CLASSES = [];
 

--- a/src/htdocs/css/_MagnitudeSummaryView.scss
+++ b/src/htdocs/css/_MagnitudeSummaryView.scss
@@ -1,0 +1,8 @@
+
+.magnitude-summary-view {
+  > div {
+    /* TODO, remove (just for scaffolding) */
+    border: 1px solid #ccc;
+    padding: 1em;
+  }
+}

--- a/src/htdocs/css/_MagnitudeSummaryView.scss
+++ b/src/htdocs/css/_MagnitudeSummaryView.scss
@@ -1,8 +1,5 @@
-
-.magnitude-summary-view {
-  > div {
-    /* TODO, remove (just for scaffolding) */
-    border: 1px solid #ccc;
-    padding: 1em;
-  }
+.magnitude-beachball > div {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/htdocs/css/magnitude.scss
+++ b/src/htdocs/css/magnitude.scss
@@ -1,1 +1,2 @@
 @import '_MagnitudeCollectionTable.scss';
+@import '_MagnitudeSummaryView.scss';

--- a/src/htdocs/js/BeachBallView.js
+++ b/src/htdocs/js/BeachBallView.js
@@ -1,0 +1,881 @@
+/* This is based on code in GMT, utilmeca.c. */
+'use strict';
+
+var Canvas = require('Canvas'),
+    Util = require('util/Util'),
+    View = require('mvc/View');
+
+
+var _D2R,
+    _DEFAULTS,
+    _EPSILON,
+    _MERGE_THRESHOLD,
+    _R2D,
+    _SPLIT_THRESHOLD;
+
+_D2R = Math.PI / 180;
+_R2D = 180 / Math.PI;
+
+_EPSILON = Number.EPSILON || 1e-16;
+
+// threshold x and y pixel difference when polygons should be merged.
+// Pixels are in the range [-1, 1], so 0.02 represents a 1% difference.
+_MERGE_THRESHOLD = 0.02;
+
+// threshold takeoff angle when polygons should be split.
+_SPLIT_THRESHOLD = 85 * _D2R;
+
+_DEFAULTS = {
+  axisSize: null,
+  bgColor: '#fff',
+  fillColor: '#ddd',
+  height: null,
+  labelAxes: true,
+  labelAxesFont: '24px Arial',
+  labelPlanes: true,
+  labelPlanesFont: '14px Arial',
+  lineColor: '#000',
+  lineWidth: 0.25,
+  plotAxes: false,
+  plotPlanes: true,
+  radius: null,
+  size: 200,
+  tensor: null,
+  width: null,
+  x0: null,
+  y0: null
+};
+
+
+/**
+ * Make sure number is between 0 and 2pi.
+ *
+ * @param value {Number}
+ *     angle in radians.
+ * @return {Number}
+ *     angle in radians, in the range [0, 2pi).
+ */
+var __0To2Pi = function (value) {
+  var twoPi;
+
+  twoPi = 2 * Math.PI;
+  while (value < 0) {
+    value += twoPi;
+  }
+  while (value >= twoPi) {
+    value -= twoPi;
+  }
+  return value;
+};
+
+/**
+ * Compute trig values of axis.
+ *
+ * @param axis {Vector3}
+ *        principal axis, with value property.
+ * @return {Object} with these keys:
+ *         v: value,
+ *         a: azimuth,
+ *         ca: cos(azimuth),
+ *         sa: sin(azimuth),
+ *         p: plunge,
+ *         cp: cos(plunge),
+ *         sp: sin(plunge).
+ */
+var __axisCache = function (axis) {
+  var azimuth,
+      plunge;
+
+  // Vector azimuth method returns clockwise from north
+  // code in this file expects counter-clockwise from east
+  azimuth = (Math.PI / 2) - axis.azimuth();
+  plunge = axis.plunge();
+  // make axis plunge downward (negative values are up)
+  if (plunge < 0) {
+    plunge *= -1;
+    azimuth += Math.PI;
+  }
+  // make azimuth in range [0, 2*PI)
+  azimuth = __0To2Pi(azimuth, 0, Math.PI * 2);
+
+  return {
+    v: axis.eigenvalue,
+    a: azimuth,
+    ca: Math.cos(azimuth),
+    sa: Math.sin(azimuth),
+    p: plunge,
+    cp: Math.cos(plunge),
+    sp: Math.sin(plunge)
+  };
+};
+
+
+var BeachBallView = function (options) {
+  var _this,
+      _initialize,
+
+      _axisSize,
+      _bgColor,
+      _canvas,
+      _fillColor,
+      _height,
+      _labelAxes,
+      _labelAxesFont,
+      _labelPlanes,
+      _labelPlanesFont,
+      _lineColor,
+      _lineWidth,
+      _plotAxes,
+      _plotPlanes,
+      _radius,
+      _size,
+      _tensor,
+      _width,
+      _x0,
+      _y0;
+
+  _this = View(options);
+
+  _initialize = function (options) {
+    options = Util.extend({}, _DEFAULTS, options);
+
+    _bgColor = options.bgColor;
+    _fillColor = options.fillColor;
+    _labelAxes = options.labelAxes;
+    _labelAxesFont = options.labelAxesFont;
+    _labelPlanes = options.labelPlanes;
+    _labelPlanesFont = options.labelPlanesFont;
+    _lineColor = options.lineColor;
+    _lineWidth = options.lineWidth;
+    _plotAxes = options.plotAxes;
+    _plotPlanes = options.plotPlanes;
+    _size = options.size;
+    _tensor = options.tensor;
+
+    // options with computed defaults
+    _radius = options.radius || parseInt((_size - 2) / 2, 10);
+    _axisSize = options.axisSize || parseInt(_radius / 12.5, 10);
+    _height = options.height || _size;
+    _width = options.width || _size;
+    _x0 = options.x0 || _width / 2;
+    _y0 = options.y0 || _height / 2;
+  };
+
+
+  /**
+   * Complete polygon, by inserting points at edge of circle.
+   *
+   * @param poly {Object}
+   *     polygon to potentially complete.
+   * @return {Object}
+   *     completed polygon.
+   */
+  _this.completePolygon = function (polygon) {
+    var az,
+        az1,
+        az2,
+        x,
+        y;
+
+    if (polygon.x.length === 360) {
+      // already a complete polygon
+      return polygon;
+    }
+
+    az1 = polygon.startAz.az;
+    az2 = polygon.endAz.az;
+    x = polygon.x;
+    y = polygon.y;
+    // fill in circle portion of polygons
+    if (az1 - az2 > Math.PI) {
+      az1 -= 2 * Math.PI;
+    }
+    if (az2 - az1 > Math.PI) {
+      az1 += 2 * Math.PI;
+    }
+    if (az1 < az2) {
+      for (az = az2 - _D2R; az > az1; az -= _D2R) {
+        x.push(Math.sin(az));
+        y.push(Math.cos(az));
+      }
+    } else {
+      for (az = az2 + _D2R; az < az1; az += _D2R) {
+        x.push(Math.sin(az));
+        y.push(Math.cos(az));
+      }
+    }
+
+    return polygon;
+  };
+
+  /**
+   * Compute azimuth label relative positioning.
+   *
+   * @param label {Object}
+   * @return {Object}
+   *     same `label` object, with additional properties:
+   *     - `align` {String}
+   *         'left' or 'right'
+   *     - `size` {Object}
+   *         `width` and `height` of label
+   *     - `tick` {Object}
+   *         `x` and `y` relative tick coordinates.
+   *     - `x` {Number}
+   *         relative x coordinate of label.
+   *     - `y` {Number}
+   *         relative y coordinate of label.
+   */
+  _this.computeAzimuthLabel = function (label) {
+    var align,
+        point,
+        labelOffset,
+        size,
+        tickLength,
+        x,
+        y;
+
+    // point on edge
+    point = _this.getPoint(label.azimuth, 0);
+    x = point.x;
+    y = point.y;
+    align = (x < 0) ? 'right' : 'left';
+    size = _this.measureText(label.text, label.font);
+
+    labelOffset = (_radius + 10) / _radius;
+    tickLength = (_radius + 5) / _radius;
+
+    label.align = align;
+    label.size = size;
+    label.tick = {
+      x: [x, x * tickLength],
+      y: [y, y * tickLength],
+    };
+    label.x = x * labelOffset;
+    label.y = y * labelOffset;
+
+    if (y < 0) {
+      // shift label down when in bottom half
+      label.y = y * (_radius + 10 + Math.abs(y) * size.height / 2) / _radius;
+    }
+
+    return label;
+  };
+
+  /**
+   * Free references.
+   */
+  _this.destroy = Util.compose(function () {
+    if (!_this) {
+      return;
+    }
+
+    _axisSize = null;
+    _bgColor = null;
+    _fillColor = null;
+    _labelAxes = null;
+    _labelAxesFont = null;
+    _labelPlanes = null;
+    _labelPlanesFont = null;
+    _lineColor = null;
+    _lineWidth = null;
+    _plotAxes = null;
+    _plotPlanes = null;
+    _size = null;
+    _tensor = null;
+
+    _radius = null;
+    _height = null;
+    _width = null;
+    _x0 = null;
+    _y0 = null;
+
+    _this = null;
+    _initialize = null;
+  }, _this.destroy);
+
+  /**
+   * Get a line for a nodal plane.
+   *
+   * @param np {Object}
+   *     Nodal plane object with keys `strike`, `dip`, and `rake` and
+   *     values in degrees.
+   * @return {Object}
+   *     With properties `x` and `y` that are Arrays of points in the
+   *     range [-1, 1].
+   */
+  _this.getPlaneLine = function (np) {
+    var dip,
+        j,
+        point,
+        strike,
+        tanDip,
+        vertical,
+        x,
+        y;
+
+    strike = np.strike * _D2R;
+    dip = np.dip * _D2R;
+    x = [];
+    y = [];
+
+    vertical = (Math.abs(dip - Math.PI / 2)) < _EPSILON;
+    if (vertical) {
+      x.push(Math.sin(strike), Math.sin(strike + Math.PI));
+      y.push(Math.cos(strike), Math.cos(strike + Math.PI));
+    } else {
+      tanDip = Math.tan(dip);
+      for (j = 0; j <= Math.PI; j += _D2R) {
+        // dip from [0,0,0] to intersection of plane and focal sphere
+        // at azimuth `strike + j`
+        dip = Math.atan(tanDip * Math.sin(j));
+        point = _this.getPoint(strike + j, dip);
+        x.push(point.x);
+        y.push(point.y);
+      }
+    }
+
+    return {
+      x: x,
+      y: y
+    };
+  };
+
+  /**
+   * Get x, y coordinates for a vector.
+   *
+   * @param vector {Vector}
+   *     vector reprenenting point.
+   * @return {Object}
+   *     with properties `x` and `y` in the range [-1, 1] representing location
+   *     of point in focal sphere.
+   */
+  _this.getPoint = function (azimuth, plunge) {
+    var r,
+        x,
+        y;
+
+    if (plunge < 0) {
+      plunge *= -1;
+      azimuth += Math.PI;
+    }
+    azimuth = __0To2Pi(azimuth);
+
+    r = Math.sqrt(1 - Math.sin(plunge));
+    x = r * Math.sin(azimuth);
+    y = r * Math.cos(azimuth);
+
+    return {
+      x: x,
+      y: y
+    };
+  };
+
+  /**
+   * Get Polygons representing pressure and tension regions of the beachball.
+   *
+   * May swap foreground and background colors.
+   *
+   * @param tensor {Tensor}
+   *        tensor.
+   * @return {Array<Object>} each object will have properties:
+   *         x: {Array<Number>} x coordinates of line,
+   *         y: {Array<Number} y coordinates of line,
+   *         startAz: {Object} start azimuth of line,
+   *         endAz: {Object} end azimuth of line.
+   */
+  _this.getPolygons = function (tensor) {
+    var alphan,
+        az,
+        azes,
+        azp,
+        c,
+        cfi,
+        f,
+        fir,
+        i,
+        iso,
+        n,
+        p,
+        polygon,
+        polygons,
+        r,
+        s,
+        s2alphan,
+        sfi,
+        swapColors,
+        t,
+        tmp,
+        takeoff,
+        vi,
+        x,
+        xe,
+        xn,
+        xz,
+        y;
+
+    t = __axisCache(tensor.T);
+    n = __axisCache(tensor.N);
+    p = __axisCache(tensor.P);
+
+    azes = [];
+    polygons = [];
+
+
+    vi = (t.v + n.v + p.v) / 3;
+    t.v -= vi;
+    n.v -= vi;
+    p.v -= vi;
+
+    // compute f, iso
+    f = (-n.v / t.v) || _EPSILON;
+    iso = (vi / t.v) || _EPSILON;
+
+    // build azes
+    swapColors = false;
+    for (i = 0; i < 360; i++) {
+      fir = i * _D2R;
+      sfi = Math.sin(fir);
+      cfi = Math.cos(fir);
+      s2alphan = (2 + 2 * iso) / (3 + (1 - 2 * f) * Math.cos(2 * fir));
+      if (Math.abs(1 - s2alphan) <= _EPSILON) {
+        s2alphan = 1;
+      }
+      if (s2alphan > 1) {
+        // swap axes
+        tmp = t;
+        t = p;
+        p = tmp;
+        // swap bg/fill colors
+        swapColors = !swapColors;
+        // recompute f, iso, s2alphan
+        f = (-n.v / t.v) || _EPSILON;
+        iso = (vi / t.v) || _EPSILON;
+        s2alphan = (2 + 2 * iso) / (3 + (1 - 2 * f) * Math.cos(2 * fir));
+      }
+      // compute z,n,e components
+      alphan = Math.asin(Math.sqrt(s2alphan));
+      s = Math.sin(alphan);
+      c = Math.cos(alphan);
+      xz = c * t.sp        + s * sfi * n.sp        + s * cfi * p.sp;
+      xn = c * t.cp * t.ca + s * sfi * n.cp * n.ca + s * cfi * p.cp * p.ca;
+      xe = c * t.cp * t.sa + s * sfi * n.cp * n.sa + s * cfi * p.cp * p.sa;
+      // compute azimuth and takeoff angle
+      if (Math.abs(xn) < _EPSILON && Math.abs(xe) < _EPSILON) {
+        az = 0;
+        takeoff = 0;
+      } else {
+        az = __0To2Pi(Math.atan2(xe, xn));
+        takeoff = Math.acos(xz / Math.sqrt(xz*xz + xn*xn + xe*xe));
+        if (takeoff > Math.PI / 2) {
+          az = __0To2Pi(az + Math.PI);
+          takeoff = Math.PI - takeoff;
+        }
+      }
+      // save for later
+      azes.push({
+        az: az,
+        takeoff: takeoff
+      });
+    }
+
+    // build polygons
+    polygon = null;
+    for (i = 0; i < azes.length; i++) {
+      az = azes[i];
+      r = Math.SQRT2 * Math.sin(az.takeoff / 2);
+      x = r * Math.sin(az.az);
+      y = r * Math.cos(az.az);
+      if (polygon !== null) {
+        // check if current point should be part of this polygon
+        azp = azes[(i === 0) ? azes.length - 1 : i - 1];
+        if (Math.abs(Math.abs(az.az - azp.az) - Math.PI) < 10 * _D2R) {
+          // polygons should only end at edge of beachball
+          if (az.takeoff > _SPLIT_THRESHOLD &&
+              azp.takeoff > _SPLIT_THRESHOLD) {
+            // end a polygon
+            if (polygon !== null) {
+              polygon.endAz = azp;
+              polygons.push(polygon);
+              polygon = null;
+            }
+          }
+        }
+      }
+      if (polygon === null) {
+        // start a polygon
+        polygon = {
+          x: [],
+          y: [],
+          startAz: az,
+          endAz: null
+        };
+      }
+      // add point to current polygon
+      polygon.x.push(x);
+      polygon.y.push(y);
+    }
+    // close last polygon
+    polygon.endAz = azes[azes.length - 1];
+    polygons.push(polygon);
+
+    // fix up polygons
+    polygons = _this.mergePolygons(polygons);
+    polygons = polygons.map(_this.completePolygon);
+    polygons.swapColors = swapColors;
+    return polygons;
+  };
+
+  /**
+   * Call getPoint using a Vector.
+   *
+   * Vector azimuth is reported counter-clockwise from east.
+   * getPoint expects azimuth to be clockwise from north.
+   *
+   * @param vector {Vector}
+   *     the vector.
+   * @return {Object}
+   *     relative point within focal sphere.
+   */
+  _this.getVectorPoint = function (vector) {
+    return _this.getPoint(
+      (Math.PI / 2) - vector.azimuth(),
+      vector.plunge()
+    );
+  };
+
+  /**
+   * Measure pixel size of text.
+   *
+   * @param text {String}
+   *     text to measure.
+   * @param font {String}
+   *     css/canvas font property.
+   * @return {Object}
+   *     with `width` and `height` properties that are the pixel size of `text`.
+   */
+  _this.measureText = function (text, font) {
+    var el,
+        size;
+
+    // create hidden element with text content
+    el = document.createElement('div');
+    el.setAttribute('style',
+        'height:auto;' +
+        'position:absolute;' +
+        'visibility:hidden;' +
+        'white-space:nowrap;' +
+        'width:auto;' +
+        'font:' + font + ';');
+    el.innerText = text;
+
+    // add to view element and measure
+    _this.el.appendChild(el);
+    size = {
+      height: el.scrollHeight,
+      width: el.scrollWidth
+    };
+
+    // clean up
+    _this.el.removeChild(el);
+    el = null;
+
+    return size;
+  };
+
+  /**
+   * Label an axis.
+   *
+   * @param axis {Vector}
+   *     axis to label.
+   * @param text {String}
+   *     axis label.
+   */
+  _this.labelAxis = function (axis, text) {
+    var point;
+
+    point = _this.getVectorPoint(axis);
+    _canvas.text(text,
+        _labelAxesFont,
+        _this.projectX(point.x),
+        _this.projectY(point.y),
+        null,
+        'black',
+        'center');
+  };
+
+  /**
+   * Draw an azimuth label.
+   *
+   * @param label {Object}
+   *     label object with `azimuth`, `text`, and `font` properties.
+   */
+  _this.labelAzimuth = function (label) {
+    var tick;
+
+    if (!('size' in label)) {
+      label = _this.computeAzimuthLabel(label);
+    }
+
+    tick = label.tick;
+    _canvas.line(
+        tick.x.map(_this.projectX),
+        tick.y.map(_this.projectY),
+        'black');
+
+    _canvas.text(label.text, label.font,
+        _this.projectX(label.x),
+        _this.projectY(label.y),
+        null,
+        'black',
+        label.align);
+  };
+
+  /**
+   * Adjust size to make room for azimuth labels.
+   *
+   * Updates _canvas, _height, _width, _x0, and _y0.
+   * Resets canvas content, any rendering should occur after calling.
+   *
+   * @param label {Object}
+   *     label object with `azimuth`, `text`, and `font` properties.
+   */
+  _this.makeRoomForAzimuthLabel = function (label) {
+    var bottom,
+        left,
+        right,
+        size,
+        top,
+        x,
+        y;
+
+    if (!('size' in label)) {
+      label = _this.computeAzimuthLabel(label);
+    }
+
+    x = _this.projectX(label.x);
+    y = _this.projectY(label.y);
+    size = label.size;
+
+    // measure actual top/right/bottom/left
+    bottom = 0;
+    left = 0;
+    right = 0;
+    top = 0;
+    bottom = y - size.height;
+    top = y + size.height;
+    if (label.align === 'left') {
+      left = x;
+      right = x + size.width;
+    } else {
+      left = x - size.width;
+      right = x;
+    }
+
+    // convert from actual size to relative size increase
+    if (bottom < 0) {
+      bottom = Math.abs(bottom);
+    } else {
+      bottom = 0;
+    }
+    if (top > _height) {
+      top = top - _height;
+    } else {
+      top = 0;
+    }
+    if (left < 0) {
+      left = Math.abs(left);
+    } else {
+      left = 0;
+    }
+    if (right > _width) {
+      right = right - _width;
+    } else {
+      right = 0;
+    }
+
+    // change size
+    _width = _width + left + right;
+    _x0 = _x0 + left;
+    _height = _height + top + bottom;
+    _y0 = _y0 + top;
+  };
+
+  /**
+   * Merge adjacent lines that should be part of the same polygon.
+   *
+   * @param polygons {Array<Object>}
+   *     array of polygons to potentially merge.
+   * @return {Array<Object>}
+   *     array of polygons that remain after any merges.
+   */
+  _this.mergePolygons = function (polygons) {
+    var i,
+        nextI,
+        p1,
+        p1x,
+        p1y,
+        p2,
+        p2x,
+        p2y;
+
+    if (polygons.length === 1) {
+      // nothing to merge
+      return polygons;
+    }
+
+    for (i = 0; i < polygons.length; i++) {
+      nextI = (i === polygons.length - 1 ? 0 : i + 1);
+      p1 = polygons[i];
+      p1x = p1.x;
+      p1y = p1.y;
+      p2 = polygons[nextI];
+      p2x = p2.x;
+      p2y = p2.y;
+      if (Math.abs(p1x[p1x.length - 1] - p2x[0]) < _MERGE_THRESHOLD &&
+          Math.abs(p1y[p1y.length - 1] - p2y[0]) < _MERGE_THRESHOLD) {
+        // merge polygons
+        p1x.push.apply(p1x, p2x);
+        p1y.push.apply(p1y, p2y);
+        p1.endAz = p2.endAz;
+        polygons.splice(nextI, 1);
+      }
+    }
+    return polygons;
+  };
+
+  /**
+   * Convert a relative x coordinate to a canvas pixel coordinate.
+   *
+   * @param x {Number}
+   *     relative x coordinate.
+   * @return {Number}
+   *     canvas pixel x coordinate.
+   */
+  _this.projectX = function (x) {
+    return _x0 + _radius * x;
+  };
+
+  /**
+   * Convert a relative y coordinate to a canvas pixel coordinate.
+   *
+   * @param y {Number}
+   *     relative y coordinate.
+   * @return {Number}
+   *     canvas pixel y coordinate.
+   */
+  _this.projectY = function (y) {
+    return _height - (_y0 + _radius * y);
+  };
+
+  /**
+   * Render view based on current model settings.
+   */
+  _this.render = function () {
+    var azimuthLabels,
+        point,
+        polygons,
+        tmp,
+        x,
+        y;
+
+    azimuthLabels = [];
+    // create azimuth labels, for now only nodal planes.
+    if (_labelPlanes) {
+      [_tensor.NP1, _tensor.NP2].forEach(function (np) {
+        var azimuth,
+            text;
+
+        azimuth = np.strike * _D2R;
+        text = '(' +
+            np.strike.toFixed(0) + ', ' +
+            np.dip.toFixed(0) + ', ' +
+            np.rake.toFixed(0) +
+            ')';
+        azimuthLabels.push({
+          'azimuth': azimuth,
+          'font': _labelPlanesFont,
+          'text': text
+        });
+      });
+    }
+    // adjust plot area so labels are visible.
+    azimuthLabels.forEach(_this.makeRoomForAzimuthLabel);
+
+    _canvas = Canvas({
+      height: _height,
+      width: _width
+    });
+    _canvas.context.lineWidth = _lineWidth;
+
+    // get polygons
+    // represents either solid regions (swapColors = false),
+    // or holes (swapColors = true)
+    polygons = _this.getPolygons(_tensor);
+    if (polygons.swapColors) {
+      tmp = _bgColor;
+      _bgColor = _fillColor;
+      _fillColor = tmp;
+    }
+
+    // center of beachball.
+    x = _this.projectX(0);
+    y = _this.projectY(0);
+
+    // plot circle outline, with background color
+    // in case polygons represent holes
+    _canvas.circle(x, y, _radius * 2, _lineColor, _bgColor);
+
+    // draw polygons
+    polygons.forEach(function(p) {
+      _canvas.polygon(
+          p.x.map(_this.projectX),
+          p.y.map(_this.projectY),
+          _lineColor,
+          _fillColor);
+    });
+
+    // draw nodal plane lines
+    if (_plotPlanes) {
+      [_tensor.NP1, _tensor.NP2].forEach(function (np) {
+        var line;
+        line = _this.getPlaneLine(np);
+        _canvas.line(
+            line.x.map(_this.projectX),
+            line.y.map(_this.projectY),
+            _lineColor);
+      });
+    }
+
+    // plot circle without fill, in case polygons covered outline.
+    _canvas.circle(x, y, _radius * 2, _lineColor);
+
+    if (_labelAxes) {
+      _this.labelAxis(_tensor.P, 'P');
+      _this.labelAxis(_tensor.T, 'T');
+    } else if (_plotAxes) {
+      point = _this.getVectorPoint(_tensor.P);
+      _canvas.circle(point.x, point.y, _axisSize, 'white', 'black');
+      point = _this.getVectorPoint(_tensor.T);
+      _canvas.circle(point.x, point.y, _axisSize, 'black', 'white');
+    }
+
+    // draw azimuth labels
+    azimuthLabels.forEach(_this.labelAzimuth);
+
+    Util.empty(_this.el);
+    _this.el.appendChild(_canvas.canvas);
+    _canvas.destroy();
+    _canvas = null;
+  };
+
+
+  _initialize(options);
+  options = null;
+  return _this;
+};
+
+
+BeachBallView.zeroToTwoPi = __0To2Pi;
+
+
+module.exports = BeachBallView;

--- a/src/htdocs/js/Canvas.js
+++ b/src/htdocs/js/Canvas.js
@@ -1,0 +1,256 @@
+'use strict';
+
+var Util = require('util/Util');
+
+
+var _DEFAULTS = {
+  canvas: null,
+  height: 100,
+  width: 100
+};
+
+
+/**
+ * Create a new Canvas object.
+ *
+ * @param options {Object}
+ * @param options.canvas {DOMElement}
+ *        Optional, An existing canvas element.
+ *        If omitted, a new canvas element is created.
+ * @param options.width {Number}
+ *        Optional, default 100.
+ *        Width of canvas, when options.canvas is null.
+ * @param options.height {Number}
+ *        Optional, default 100.
+ *        Height of canvas, when options.canvas is null.
+ */
+var Canvas = function (options) {
+  var _this,
+      _initialize,
+
+      _canvas,
+      _context;
+
+  _this = {};
+
+  _initialize = function (options) {
+    options = Util.extend({}, _DEFAULTS, options);
+
+    _canvas = options.canvas;
+    if (_canvas === null) {
+      _canvas = document.createElement('canvas');
+      _canvas.width = options.width;
+      _canvas.height = options.height;
+    }
+    _context = _canvas.getContext('2d');
+    // expose these as public properties
+    _this.canvas = _canvas;
+    _this.context = _context;
+  };
+
+
+  /**
+   * Clear the canvas.
+   */
+  _this.clear = function () {
+    if (_context.clearRect) {
+      _context.clearRect(0, 0, _canvas.width, _canvas.height);
+    } else {
+      _canvas.width = _canvas.width;
+    }
+  };
+
+  /**
+   * Free references.
+   */
+  _this.destroy = function () {
+    _canvas = null;
+    _context = null;
+    _initialize = null;
+    _this = null;
+  };
+
+  /**
+   * Draw a circle
+   *
+   * @param x {Number}
+   *        center of circle.
+   * @param y {Number}
+   *        center of circle.
+   * @param size {Number}
+   *        diameter of circle.
+   * @param stroke {String}
+   *        strokeStyle, or null to not stroke.
+   * @param fill {String}
+   *        fillStyle, or null to not fill.
+   */
+  _this.circle = function (x, y, size, stroke, fill) {
+    var c;
+
+    c = _context;
+    c.beginPath();
+    c.arc(x, y, size/2, 0, Math.PI*2, true);
+    c.closePath();
+
+    _this._strokeAndFill(stroke, fill);
+  };
+
+  /**
+   * Draw a polygon
+   *
+   * @param x {Array<Number>}
+   *        array of x coordinates.
+   * @param y {Array<Number>}
+   *        array of y coordinates.
+   * @param stroke {String}
+   *        strokeStyle, or null to not stroke.
+   * @param fill {String}
+   *        fillStyle, or null to not fill.
+   */
+  _this.polygon = function (x, y, stroke, fill) {
+    var c,
+        i,
+        len;
+
+    c = _context;
+    c.beginPath();
+    c.moveTo(x[0], y[0]);
+    for (i = 1, len = x.length; i < len; i++) {
+      c.lineTo(x[i], y[i]);
+    }
+    c.closePath();
+
+    _this._strokeAndFill(stroke, fill);
+  };
+
+  /**
+   * Draw a line.
+   *
+   * Same as polygon, without closingPath before calling stroke/fill.
+   *
+   * @param x {Array<Number>}
+   *        array of x coordinates.
+   * @param y {Array<Number}
+   *        array of y coordinates.
+   * @param stroke {String}
+   *        strokeStyle, or null to not stroke.
+   * @param fill {String}
+   *        fillStyle, or null to not fill.
+   */
+  _this.line = function (x, y, stroke, fill) {
+    var c,
+        i,
+        len;
+
+    c = _context;
+    c.beginPath();
+    c.moveTo(x[0], y[0]);
+    for (i = 1, len = x.length; i < len; i++) {
+      c.lineTo(x[i], y[i]);
+    }
+
+    this._strokeAndFill(stroke, fill);
+  };
+
+  /**
+   * Measure how many pixels are needed to plot text in the given font.
+   *
+   * @param font {String}
+   *     context font property.
+   * @param text {String}
+   *     text to plot.
+   * @return {TextMetrics}
+   *     size of text once plotted, "width" is the only widely supported
+   *     TextMetrics property.
+   */
+  _this.measureText = function (font, text) {
+    var c;
+
+    c = _context;
+    c.font = font;
+    return c.measureText(text);
+  };
+
+  /**
+   * Draw text.
+   *
+   * @param text {String}
+   *        text to draw.
+   * @param font {String}
+   *        font to use, e.g. '30px Arial'.
+   * @param x {Number}
+   *        x coordinate.
+   * @param y {Number}
+   *        y coordinate.
+   * @param stroke {String}
+   *        strokeStyle, or null to not stroke.
+   * @param fill {String}
+   *        fillStyle, or null to not fill.
+   * @param align {String} default 'left'
+   *        where to align text around x.
+   *        'left' starts at x.
+   *        'center' centers around x.
+   *        'right' ends at x.
+   */
+  _this.text = function (text, font, x, y, stroke, fill, align) {
+    var c,
+        size;
+
+    c = _context;
+    align = align || 'left';
+
+    c.font = font;
+    if (align !== 'left') {
+      size = c.measureText(text);
+      if (align === 'center') {
+        x = x - size.width / 2;
+      } else if (align === 'right') {
+        x = x - size.width;
+      }
+    }
+
+    if (stroke) {
+      c.strokeStyle = stroke;
+      c.strokeText(text, x, y);
+    }
+
+    if (fill) {
+      c.fillStyle = fill;
+      c.fillText(text, x, y);
+    }
+  };
+
+
+  /**
+   * Stroke and fill the current path.
+   *
+   * @param context {Object}
+   *        canvas context
+   * @param stroke {String}
+   *        strokeStyle, or null to not stroke.
+   * @param fill {String}
+   *        fillStyle, or null to not fill.
+   */
+  _this._strokeAndFill = function (stroke, fill) {
+    var c;
+
+    c = _context;
+
+    if (stroke) {
+      c.strokeStyle = stroke;
+      c.stroke();
+    }
+    if (fill) {
+      c.fillStyle = fill;
+      c.fill();
+    }
+  };
+
+
+  _initialize(options);
+  options = null;
+  return _this;
+};
+
+
+module.exports = Canvas;

--- a/src/htdocs/js/EventModel.js
+++ b/src/htdocs/js/EventModel.js
@@ -1,13 +1,12 @@
 'use strict';
 
 
-var Model = require('mvc/Model'),
+var FeatureModel = require('FeatureModel'),
     Util = require('util/Util');
 
 
 var _DEFAULTS,
-    _fromFeature,
-    _parseAttributes;
+    _fromFeature;
 
 _DEFAULTS = {
   depth: null,         // Depth of event. Number
@@ -24,7 +23,7 @@ _DEFAULTS = {
 
 
 /**
- * Model for representing an event. This class directly extends {mvc/Model}.
+ * Model for representing an event. This class directly extends {FeatureModel}.
  * The primary value from this class is the static `fromFeature` method
  * that parses a GeoJSON feature to produce an event model.
  *
@@ -32,18 +31,20 @@ _DEFAULTS = {
  *     Attributes for the model.
  */
 var EventModel = function (options) {
-  var _this;
+  var _this,
+      _initialize;
 
 
   options = Util.extend({}, _DEFAULTS, options);
-  _this = Model(options);
+  _this = FeatureModel(options);
 
-
-  _this.reset = function (attributes) {
-    _this.set(Util.extend({}, _DEFAULTS, attributes));
+  _initialize = function (/*options*/) {
+    _this.defaults = JSON.parse(JSON.stringify(_DEFAULTS));
   };
 
 
+  _initialize(options);
+  options = null;
   return _this;
 };
 
@@ -59,44 +60,16 @@ var EventModel = function (options) {
  *     An event model.
  */
 _fromFeature = function (feature) {
-  return EventModel(_parseAttributes(feature));
-};
+  var model;
 
-/**
- * Parses the provided GeoJSON Feature object into an object containing
- * attributes as necessary for an EventModel.
- *
- * @param feature {GeoJSON.Feature}
- *     A GeoJSON feature object containing properties and other data that can
- *     be used as to generate the attributes.
- *
- * @return {Object}
- *     An event model.
- */
-_parseAttributes = function (feature) {
-  var attributes,
-      coordinates;
+  model = EventModel();
+  model.reset(model.parseAttributes(feature));
 
-  if (feature) {
-    attributes = Util.extend({}, _DEFAULTS, feature.properties);
-
-    coordinates = feature.geometry ? feature.geometry.coordinates : [];
-    coordinates = coordinates || []; // if feature.geometry.coordinates is falsy
-
-    // Read other attributes off feature, preferring null over undefined ...
-    attributes.id = feature.id || null;
-    attributes.longitude = coordinates[0] || null;
-    attributes.latitude = coordinates[1] || null;
-    attributes.depth = coordinates[2] || null;
-  }
-
-  return attributes || {};
+  return model;
 };
 
 
-EventModel.NULL_MODEL = JSON.parse(JSON.stringify(_DEFAULTS));
 EventModel.fromFeature = _fromFeature;
-EventModel.parseAttributes = _parseAttributes;
 
 
 module.exports = EventModel;

--- a/src/htdocs/js/EventSearchView.js
+++ b/src/htdocs/js/EventSearchView.js
@@ -234,7 +234,7 @@ var EventSearchView = function (options) {
    *     The XMLHttpRequest for the search.
    */
   _this.onSearchError = function (err/*, xhr*/) {
-    _this.eventModel.reset(EventModel.NULL_MODEL);
+    _this.eventModel.reset();
     _this.magnitudeCollection.reset([]);
 
     _this.messageEl.innerHTML = [

--- a/src/htdocs/js/FeatureModel.js
+++ b/src/htdocs/js/FeatureModel.js
@@ -1,0 +1,82 @@
+'use strict';
+
+
+var Model = require('mvc/Model'),
+    Util = require('util/Util');
+
+
+var _DEFAULTS,
+    _fromFeature;
+
+// Enummerate all possible attributes from a feature.properties
+_DEFAULTS = {};
+
+
+var FeatureModel = function (options) {
+  var _this,
+      _initialize;
+
+
+  options = Util.extend({}, _DEFAULTS, options);
+  _this = Model(options);
+
+  _initialize = function (/*options*/) {
+    _this.defaults = JSON.parse(JSON.stringify(_DEFAULTS));
+  };
+
+
+  _this._getDefaults = function () {
+    return _this.defaults;
+  };
+
+
+  _this.augmentAttributes = function (attributes) {
+    return attributes;
+  };
+
+  _this.parseAttributes = function (feature) {
+    var attributes,
+        coordinates;
+
+    if (feature) {
+      attributes = Util.extend({}, _this._getDefaults(), feature.properties);
+
+      coordinates = feature.geometry ? feature.geometry.coordinates : [];
+      coordinates = coordinates || [];
+
+      // Read other attributes off feature, preferring null over undefined ...
+      attributes.id = feature.id || null;
+      attributes.longitude = coordinates[0] || null;
+      attributes.latitude = coordinates[1] || null;
+      attributes.depth = coordinates[2] || null;
+    }
+
+    attributes = _this.augmentAttributes(attributes);
+
+    return attributes || {};
+  };
+
+  _this.reset = function (attributes) {
+    _this.set(Util.extend({}, _this._getDefaults(), attributes));
+  };
+
+
+  _initialize(options);
+  options = null;
+  return _this;
+};
+
+
+_fromFeature = function (feature) {
+  var model;
+
+  model = FeatureModel();
+  model.reset(model.parseAttributes(feature));
+
+  return model;
+};
+
+
+FeatureModel.fromFeature = _fromFeature;
+
+module.exports = FeatureModel;

--- a/src/htdocs/js/Formatter.js
+++ b/src/htdocs/js/Formatter.js
@@ -204,6 +204,38 @@ var Formatter = function (options) {
   };
 
   /**
+   * Formats a number as an exponential.
+   *
+   * @param value {Number}
+   *     The number to format.
+   * @param units {String} Optional
+   *     The units to apply to the formatted value.
+   * @param digits {Integer}
+   *     The number of digits to use in the formatted value.
+   * @param empty {String}
+   *     A value to use if value is undefined or null.
+   *
+   * @return {String}
+   *     The value formatted in exponential notation.
+   */
+  _this.exponential = function (value, units, digits, empty) {
+    empty = (typeof empty === 'undefined') ? _empty : empty;
+    digits = (typeof digits === 'undefined') ? 3 : digits;
+    units = (typeof units === 'undefined') ? '' : (' ' + units);
+
+    if (value === null || typeof value === 'undefined') {
+      return empty;
+    } else {
+      value = Number(value);
+      if (isNaN(value)) {
+        return empty;
+      } else {
+        return value.toExponential(digits).toUpperCase() + units;
+      }
+    }
+  };
+
+  /**
    * Convert kilometers to miles.
    *
    * @param km {Number}

--- a/src/htdocs/js/Formatter.js
+++ b/src/htdocs/js/Formatter.js
@@ -73,6 +73,18 @@ var Formatter = function (options) {
     return value + '&deg;';
   };
 
+  _this.boolean = function (value, empty) {
+    if (value === null) {
+      if (typeof empty !== 'undefined') {
+        return empty;
+      } else {
+        return _empty;
+      }
+    }
+
+    return value ? 'True' : 'False';
+  };
+
   /**
    * Converts azimuth to a back azimuth (opposite direction).
    *

--- a/src/htdocs/js/MagnitudeModel.js
+++ b/src/htdocs/js/MagnitudeModel.js
@@ -1,0 +1,62 @@
+'use strict';
+
+
+var FeatureModel = require('FeatureModel'),
+    Util = require('util/Util');
+
+
+var _DEFAULTS,
+    _fromFeature;
+
+
+_DEFAULTS = {
+  'associated-by': null,
+  'associated-by-installation': null,
+  'author': null,
+  'depth': null,
+  'derived-magnitude': null,
+  'derived-magnitude-type': null,
+  'id': null,
+  'installation': null,
+  'is-internal': null,
+  'is-preferred-for-type': null,
+  'latitude': null,
+  'longitude': null,
+  'moment-tensors': [],
+  'num-stations-associated': null,
+  'num-stations-used': null
+};
+
+
+var MagnitudeModel = function (options) {
+  var _this,
+      _initialize;
+
+
+  options = Util.extend({}, _DEFAULTS, options);
+  _this = FeatureModel(options);
+
+  _initialize = function (/*options*/) {
+    _this.defaults = JSON.parse(JSON.stringify(_DEFAULTS));
+  };
+
+
+  _initialize(options);
+  options = null;
+  return _this;
+};
+
+
+_fromFeature = function (feature) {
+  var model;
+
+  model = MagnitudeModel();
+  model.reset(model.parseAttributes(feature));
+
+  return model;
+};
+
+
+MagnitudeModel.fromFeature = _fromFeature;
+
+module.exports = MagnitudeModel;

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -37,7 +37,6 @@ var MagnitudeSummaryView = function (options) {
       _ev,
       _formatter,
       _magnitudeCollectionView,
-      _magnitudeDetailsEl,
       _magnitudeVersionsEl;
 
   options = Util.extend({}, _DEFAULTS, options);
@@ -53,23 +52,17 @@ var MagnitudeSummaryView = function (options) {
     _ev = options.ev || Model();
 
     el = _this.el;
-    el.innerHTML = '<div class="magnitude-summary-view">' +
-          '<h3>Moment Summary</h3>' +
-          '<table>' +
-            '<thead>' +
-              '<tr>' +
-                '<th>Parameter</th>' +
-                '<th>Value</th>' +
-                '<th>Uncertainty</th>' +
-              '</tr>' +
-            '</thead>' +
-            '<tbody class="magnitude-details"></tbody>' +
-          '</table>' +
-          '<div class="magnitude-versions"></div>' +
-        '</div>';
+    el.innerHTML = [
+      '<div class="magnitude-summary-view">',
+        '<h3>Moment Summary</h3>',
+        '<table><tbody class="magnitude-details"></tbody></table>',
+        '<div class="magnitude-versions"></div>',
+      '</div>'
+    ].join('');
 
-    _magnitudeDetailsEl = el.querySelector('.magnitude-details');
-    _magnitudeDetailsEl.innerHTML = _this.buildMagnitudeDetailsMarkup();
+    _this.dataTableEl = el.querySelector('.magnitude-details');
+    _this.dataTableEl.innerHTML = _this.buildMagnitudeDetailsMarkup();
+
     _this.displayBeachBall();
 
     _magnitudeVersionsEl = el.querySelector('.magnitude-versions');
@@ -111,6 +104,9 @@ var MagnitudeSummaryView = function (options) {
         observations,
         percentDoubleCouple,
         source,
+        sourceTimeDecay,
+        sourceTimeDuration,
+        sourceTimeRise,
         time,
         varianceReduction;
 
@@ -147,6 +143,9 @@ var MagnitudeSummaryView = function (options) {
     percentDoubleCouple = _this.getProperty('percent-double-couple');
     source = _this.getProperty('installation') + ' - ' +
         _this.getProperty('author');
+    sourceTimeDecay = _this.getProperty('sourcetime-decaytime');
+    sourceTimeDuration = _this.getProperty('sourcetime-duration');
+    sourceTimeRise = _this.getProperty('sourcetime-risetime');
     time = _this.getProperty('derived-eventtime');
     varianceReduction = _this.getProperty('variance-reduction');
     nodalPlane1 = 'Strike: ' + _this.getProperty('nodal-plane-1-strike') +
@@ -160,168 +159,113 @@ var MagnitudeSummaryView = function (options) {
     var value = '<b>TODO</b>';
 
     markup =
-      // Event Details
-      '<tr>' +
-        '<td>Preferred Magnitude</td>' +
-        '<td>' + eventMagnitude + '</td>' +
-        '<td></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<td>Region</td>' +
-        '<td>' + eventRegion + '</td>' +
-        '<td></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<td>Time</td>' +
-        '<td>' + _formatter.datetime(Date.parse(eventTime)) + '</td>' +
-        '<td></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<td>Location</td>' +
-        '<td>' + _formatter.location(eventLatitude, eventLongitude) + '</td>' +
-        '<td></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<td>Depth</td>' +
-        '<td>' + _formatter.distance(eventDepth, 'km') + '</td>' +
-        '<td></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<td>Time Since</td>' +
-        '<td class="timer-count-up"></td>' +
-        '<td></td>' +
-      '</tr>' +
-
-      // Magnitude Details
       '<tr>' +
         '<td>Magnitude</td>' +
         '<td>' + magnitude + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Observations</td>' +
         '<td>' + observations + '</td>' +
-        '<td></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<td>Mw\'</td>' +
-        '<td>' + value + '</td>' +
-        '<td></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<td>Weight</td>' +
-        '<td>' + value + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Source</td>' +
         '<td>' + source + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Internal</td>' +
         '<td>' + isInternal + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Preferred For Type</td>' +
         '<td>' + isPreferred + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Publishable</td>' +
         '<td>' + isPublishable + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Associated By</td>' +
         '<td>' + associatedBy + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Comment</td>' +
         '<td>' + comment + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Moment</td>' +
         '<td>' + moment + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Solution Time</td>' +
         '<td>' + _formatter.datetime(Date.parse(time)) + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Solution Location</td>' +
         '<td>' + _formatter.location(latitude, longitude) + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Solution Depth</td>' +
         '<td>' + _formatter.distance(depth, 'km') + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Solution Method</td>' +
         '<td>' + value + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Fit</td>' +
         '<td>' + fit + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Variance Reduction</td>' +
         '<td>' + varianceReduction + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Percent Double Couple</td>' +
-        '<td>' + _formatter.number(percentDoubleCouple * 100, 0, '', '%') + '</td>' +
-        '<td></td>' +
+        '<td>' +
+          _formatter.number(percentDoubleCouple * 100, 0, '', '%') +
+        '</td>' +
       '</tr>' +
       '<tr>' +
         '<td>Focal Mechanism</td>' +
         '<td class="beach-ball-view"></td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Nodal Plane 1</td>' +
         '<td>' + nodalPlane1 + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Nodal Plane 2</td>' +
         '<td>' + nodalPlane2 + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Percent CLVD</td>' +
-        '<td>' + value + '</td>' +
-        '<td></td>' +
+        '<td>' +
+          _formatter.number((1 - percentDoubleCouple) * 100, 0, '', '%') +
+        '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Source Time Function</td>' +
-        '<td>' + value + '</td>' +
-        '<td></td>' +
+        '<td>Source Time Decay</td>' +
+        '<td>' + sourceTimeDecay + '</td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Source Time Duration</td>' +
+        '<td>' + sourceTimeDuration + '</td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Source Time Rise</td>' +
+        '<td>' + sourceTimeRise + '</td>' +
       '</tr>' +
       '<tr>' +
         '<td>Input Source</td>' +
         '<td>' + inputSource + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Gap</td>' +
         '<td>' + azimuthalGap + '</td>' +
-        '<td></td>' +
       '</tr>' +
       '<tr>' +
         '<td>Condition #</td>' +
         '<td>' + condition + '</td>' +
-        '<td></td>' +
       '</tr>';
 
     return markup;

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -1,14 +1,16 @@
 'use strict';
 
 
-var Formatter = require('Formatter'),
+var BeachBallView = require('BeachBallView'),
+    Collection = require('mvc/Collection'),
+    Formatter = require('Formatter'),
+    MagnitudeCollectionView = require('MagnitudeCollectionView'),
+    Tensor = require('Tensor'),
     Util = require('util/Util'),
     View = require('mvc/View');
 
 
-var _DEFAULTS;
-
-_DEFAULTS = {};
+var _DEFAULTS = {};
 
 
 var MagnitudeSummaryView = function (options) {
@@ -16,13 +18,288 @@ var MagnitudeSummaryView = function (options) {
   var _this,
       _initialize,
 
-      _formatter;
+      _collection,
+      _formatter,
+      _magnitudeCollectionView,
+      _magnitudeDetailsEl,
+      _magnitudeVersionsEl,
+      _tensor;
 
   options = Util.extend({}, _DEFAULTS, options);
   _this = View(options);
 
   _initialize = function (options) {
-    _formatter = options.formatter || Formatter();
+    var el,
+        type;
+
+    _formatter = Formatter({
+      empty: ''
+    });
+    _collection = options.collection || Collection();
+
+    type = _this.getProperty('derived-magnitude-type');
+    type = (!type ? _this.getProperty('beachball-type') : '');
+    _tensor = Tensor({
+      'depth': _this.getProperty('derived-depth'),
+      'mrr': Number(_this.getProperty('tensor-mrr')),
+      'mtt': Number(_this.getProperty('tensor-mtt')),
+      'mpp': Number(_this.getProperty('tensor-mpp')),
+      'mrt': Number(_this.getProperty('tensor-mrt')),
+      'mrp': Number(_this.getProperty('tensor-mrp')),
+      'mtp': Number(_this.getProperty('tensor-mtp')),
+      'type': type,
+    });
+
+    el = _this.el;
+    el.innerHTML = '<div class="magnitude-summary-view">' +
+          '<table>' +
+            '<thead>' +
+              '<tr>' +
+                '<th>Parameter</th>' +
+                '<th>Value</th>' +
+                '<th>Uncertainty</th>' +
+              '</tr>' +
+            '</thead>' +
+            '<tbody class="magnitude-details"></tbody>' +
+          '</table>' +
+          '<div class="magnitude-versions"></div>' +
+        '</div>';
+
+    _magnitudeDetailsEl = el.querySelector('.magnitude-details');
+    _magnitudeDetailsEl.innerHTML = _this.buildMagnitudeDetailsMarkup();
+    _this.displayBeachBall();
+
+    _magnitudeVersionsEl = el.querySelector('.magnitude-versions');
+    _magnitudeCollectionView = MagnitudeCollectionView({
+      el: _magnitudeVersionsEl,
+      collection: _collection,
+      model: _this.model
+    });
+    _magnitudeCollectionView.render();
+  };
+
+  _this.buildMagnitudeDetailsMarkup = function () {
+    var associatedBy,
+        azimuthalGap,
+        comment,
+        condition,
+        depth,
+        fit,
+        inputSource,
+        internal,
+        latitude,
+        longitude,
+        magnitude,
+        markup,
+        moment,
+        nodalPlane1,
+        nodalPlane2,
+        observations,
+        percentDoubleCouple,
+        preferred,
+        publishable,
+        source,
+        time,
+        varianceReduction;
+
+    associatedBy = _this.getProperty('associated-by-installation') + ' - ' +
+        _this.getProperty('associated-by');
+    azimuthalGap = _this.getProperty('azimuthal-gap');
+    comment = _this.getProperty('comment');
+    condition = _this.getProperty('condition');
+    depth = _this.getProperty('derived-depth');
+    fit = _this.getProperty('fit');
+    inputSource = _this.getProperty('inputSource');
+    internal = _this.getProperty('is-internal');
+    latitude = _this.getProperty('derived-latitude');
+    longitude = _this.getProperty('derived-longitude');
+    magnitude = _this.getProperty('derived-magnitude') + ' ' +
+        _this.getProperty('derived-magnitude-type');
+    moment = _this.getProperty('scalar-moment');
+    observations = _this.getProperty('num-stations-used') + ' (' +
+        _this.getProperty('num-stations-associated') + ')';
+    percentDoubleCouple = _this.getProperty('percent-double-couple');
+    preferred = _this.getProperty('is-preferred-for-type');
+    publishable = _this.getProperty('is-publishable');
+    source = _this.getProperty('installation') + ' - ' +
+        _this.getProperty('author');
+    time = _this.getProperty('derived-eventtime');
+    varianceReduction = _this.getProperty('variance-reduction');
+    nodalPlane1 = 'Strike: ' + _this.getProperty('nodal-plane-1-strike') +
+        ' Dip: ' + _this.getProperty('nodal-plane-1-dip') +
+        ' Rake: ' + _this.getProperty('nodal-plane-1-slip');
+    nodalPlane2 = 'Strike: ' + _this.getProperty('nodal-plane-2-strike') +
+        ' Dip: ' + _this.getProperty('nodal-plane-2-dip') +
+        ' Rake: ' + _this.getProperty('nodal-plane-2-slip');
+
+    // TODO, remove this
+    var value = '<b>TODO</b>';
+
+    markup =
+      _this.buildEventDetailsMarkup() +
+      '<tr>' +
+        '<td>Magnitude</td>' +
+        '<td>' + magnitude + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Observations</td>' +
+        '<td>' + observations + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Mw\'</td>' +
+        '<td>' + value + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Weight</td>' +
+        '<td>' + value + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Source</td>' +
+        '<td>' + source + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Internal</td>' +
+        '<td>' + internal + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Preferred For Type</td>' +
+        '<td>' + preferred + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Publishable</td>' +
+        '<td>' + publishable + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Associated By</td>' +
+        '<td>' + associatedBy + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Comment</td>' +
+        '<td>' + comment + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Moment</td>' +
+        '<td>' + moment + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Solution Time</td>' +
+        '<td>' + time + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Solution Location</td>' +
+        '<td>' + _formatter.location(latitude, longitude) + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Solution Depth</td>' +
+        '<td>' + _formatter.distance(depth, 'km') + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Solution Method</td>' +
+        '<td>' + value + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Fit</td>' +
+        '<td>' + fit + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Variance Reduction</td>' +
+        '<td>' + varianceReduction + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Percent Double Couple</td>' +
+        '<td>' + _formatter.number(percentDoubleCouple * 100, 0, '', '%') + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Focal Mechanism</td>' +
+        '<td class="beach-ball-view"></td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Nodal Plane 1</td>' +
+        '<td>' + nodalPlane1 + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Nodal Plane 2</td>' +
+        '<td>' + nodalPlane2 + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Percent CLVD</td>' +
+        '<td>' + value + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Source Time Function</td>' +
+        '<td>' + value + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Input Source</td>' +
+        '<td>' + inputSource + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Gap</td>' +
+        '<td>' + azimuthalGap + '</td>' +
+        '<td></td>' +
+      '</tr>' +
+      '<tr>' +
+        '<td>Condition #</td>' +
+        '<td>' + condition + '</td>' +
+        '<td></td>' +
+      '</tr>';
+
+    return markup;
+  };
+
+  _this.getProperty = function (key) {
+    var properties;
+
+    properties = _this.model.get('properties');
+    if (properties && properties.hasOwnProperty(key)) {
+      return properties[key];
+    }
+    return '';
+  };
+
+  _this.displayBeachBall = function () {
+    var beachBallView,
+        el;
+
+    beachBallView = BeachBallView({
+      fillColor: '#ccc',
+      labelAxes: false,
+      labelPlanes: false,
+      size: 200,
+      tensor: _tensor
+    });
+    beachBallView.render();
+
+    el = _this.el.querySelector('.beach-ball-view');
+    el.appendChild(beachBallView.el);
+  };
+
+  _this.buildEventDetailsMarkup = function () {
+    return '<tr><td colspan="3">TODO:: Add 6 rows (preferred magnitude, region, time, location, depth, and time since). These details are provided by the event?</td></tr>';
   };
 
   _this.destroy = Util.compose(function () {
@@ -32,9 +309,6 @@ var MagnitudeSummaryView = function (options) {
     _this = null;
   }, _this.destroy);
 
-  _this.render = function () {
-    _this.el.innerHTML = 'TODO:: MagnitudeSummaryView';
-  };
 
   _initialize(options);
   options = null;

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -79,6 +79,8 @@ var MagnitudeSummaryView = function (options) {
       model: _this.model
     });
     _magnitudeCollectionView.render();
+
+    _this.timerCountUp(_ev.get('eventtime'));
   };
 
   _this.buildMagnitudeDetailsMarkup = function () {
@@ -186,7 +188,7 @@ var MagnitudeSummaryView = function (options) {
       '</tr>' +
       '<tr>' +
         '<td>Time Since</td>' +
-        '<td>' + value + '</td>' +
+        '<td class="timer-count-up"></td>' +
         '<td></td>' +
       '</tr>' +
 
@@ -364,6 +366,49 @@ var MagnitudeSummaryView = function (options) {
 
     el = _this.el.querySelector('.beach-ball-view');
     el.appendChild(beachBallView.el);
+  };
+
+  _this.timerCountUp = function (datetime) {
+    var current,
+        el,
+        milliseconds,
+        elapsed;
+
+    el = _this.el.querySelector('.timer-count-up');
+
+    try {
+      current = new Date().getTime();
+      milliseconds = Date.parse(datetime);
+      elapsed = Math.floor((current - milliseconds) / 1000);
+    } catch (e) {
+      el.innerHTML = '';
+      return;
+    }
+
+    window.setInterval(function () {
+      var clock,
+          days,
+          hrs,
+          mins,
+          secs,
+          weeks;
+
+      elapsed++;
+      weeks = Math.floor(elapsed/604800);
+      days = Math.floor(elapsed/86400) % 7;
+      hrs = Math.floor(elapsed/3600) % 24;
+      mins = Math.floor(elapsed/60) % 60;
+      secs = elapsed % 60;
+
+      clock =
+          (weeks ? weeks + ' weeks, ' : '') +
+          (days ? days + ' days, ' : '') +
+          (hrs ? hrs + ':' : '') +
+          (mins ? mins + ':' : '') +
+          (secs < 10 ? '0' + secs : secs);
+
+      el.innerHTML = clock;
+    }, 1000);
   };
 
   _this.destroy = Util.compose(function () {

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -175,7 +175,7 @@ var MagnitudeSummaryView = function (options) {
           '</tr>',
           '</tbody>',
         '</table>',
-        '<div class="magnitude-versions"></div>',
+        '<div class="magnitude-versions horizontal-scrolling"></div>',
       '</div>'
     ].join('');
 
@@ -266,10 +266,10 @@ _this.render = function () {
 
     mt = _this.model.get('moment-tensors')[0] || {};
 
-    _this.derivedMagnitudeEl.innerHTML = [
-      _this.model.get('derived-magnitude'), ' ',
-      _this.model.get('derived-magnitude-type')
-    ].join('');
+    _this.derivedMagnitudeEl.innerHTML = _this.formatter.magnitude(
+        _this.model.get('derived-magnitude'),
+        _this.model.get('derived-magnitude-type')
+      );
 
     _this.observationsEl.innerHTML = [
       _this.model.get('num-stations-used'), ' ',
@@ -280,9 +280,12 @@ _this.render = function () {
       _this.model.get('installation'), ' - ', _this.model.get('author')
     ].join('');
 
-    _this.internalEl.innerHTML = _this.model.get('is-internal');
-    _this.preferredEl.innerHTML = _this.model.get('is-preferred');
-    _this.publishableEl.innerHTML = _this.model.get('is-preferred');
+    _this.internalEl.innerHTML = _this.formatter.boolean(
+        _this.model.get('is-internal'));
+    _this.preferredEl.innerHTML = _this.formatter.boolean(
+        _this.model.get('is-preferred'));
+    _this.publishableEl.innerHTML = _this.formatter.boolean(
+        _this.model.get('is-preferred'));
 
     _this.associatedByEl.innerHTML = [
       _this.model.get('associated-by-installation'), ' - ',
@@ -290,7 +293,6 @@ _this.render = function () {
     ].join('');
 
     _this.commentEl.innerHTML = _this.model.get('comment');
-
 
     _this.momentEl.innerHTML = [
       (mt['scalar-moment'].toExponential(3)).toUpperCase(),
@@ -306,33 +308,35 @@ _this.render = function () {
         _this.formatter.depth(mt['derived-depth'], 'km');
 
     _this.solutionMethodEl.innerHTML = TODO;
-    _this.fitEl.innerHTML = mt.fit;
-    _this.varianceEl.innerHTML = mt['variance-reduction'];
+    _this.fitEl.innerHTML = _this.formatter.number(mt.fit, 2);
+    _this.varianceEl.innerHTML = _this.formatter.number(
+        mt['variance-reduction'], 2);
     _this.percentDcEl.innerHTML = _this.formatter.number(
         mt['percent-double-couple'] * 100, 0, '', '%');
 
     _this.np1El.innerHTML = [
-      'Strike: ', mt['nodal-plane-1-strike'], '&nbsp',
-      'Dip: ', mt['nodal-plane-1-dip'], '&nbsp',
+      'Strike: ', mt['nodal-plane-1-strike'], '&nbsp;&nbsp;',
+      'Dip: ', mt['nodal-plane-1-dip'], '&nbsp;&nbsp;',
       'Rake: ', mt['nodal-plane-1-slip']
     ].join('');
 
     _this.np2El.innerHTML = [
-      'Strike: ', mt['nodal-plane-2-strike'], '&nbsp',
-      'Dip: ', mt['nodal-plane-2-dip'], '&nbsp',
+      'Strike: ', mt['nodal-plane-2-strike'], '&nbsp;&nbsp;',
+      'Dip: ', mt['nodal-plane-2-dip'], '&nbsp;&nbsp;',
       'Rake: ', mt['nodal-plane-2-slip']
     ].join('');
 
     _this.clvdEl.innerHTML = _this.formatter.number(
         (1 - mt['percent-double-couple']) * 100, 0, '', '%');
 
-    _this.decayEl.innerHTML = mt['sourcetime-decaytime'];
-    _this.durationEl.innerHTML = mt['sourcetime-duration'];
-    _this.riseEl.innerHTML = mt['sourcetime-risetime'];
+    _this.decayEl.innerHTML = mt['sourcetime-decaytime'] + ' s';
+    _this.durationEl.innerHTML = mt['sourcetime-duration'] + ' s';
+    _this.riseEl.innerHTML = mt['sourcetime-risetime'] + ' s';
 
     _this.inputSourceEl.innerHTML = TODO;
-    _this.azimuthalGapEl.innerHTML = mt['azimuthal-gap'];
-    _this.conditionEl.innerHTML = mt.condition;
+    _this.azimuthalGapEl.innerHTML = _this.formatter.angle(mt['azimuthal-gap']);
+    _this.conditionEl.innerHTML = _this.formatter.number(mt.condition,
+        2, '');
 
     _this.renderBeachball();
     _this.renderMagnitudeTable();
@@ -347,7 +351,6 @@ _this.render = function () {
       fillColor: '#ccc',
       labelAxes: false,
       labelPlanes: false,
-      size: 200,
       tensor: _this.getTensor()
     });
 

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -229,21 +229,12 @@ var MagnitudeSummaryView = function (options) {
     _this = null;
   }, _this.destroy);
 
-  _this.getProperty = function (key) {
-    var properties;
-
-    properties = _this.model.get('properties');
-    if (properties && properties.hasOwnProperty(key)) {
-      return properties[key];
-    }
-    return '';
-  };
-
   _this.getTensor = function () {
     var mt,
         tensor;
 
-    mt = _this.model.get('moment-tensors')[0] || {};
+    mt = _this.model.get('moment-tensors');
+    mt = mt ? mt[0] : {};
 
     tensor = Tensor({
       mtt: mt['tensor-mtt'],
@@ -264,7 +255,8 @@ _this.render = function () {
     // TODO, remove this
     var TODO = '<b>TODO</b>';
 
-    mt = _this.model.get('moment-tensors')[0] || {};
+    mt = _this.model.get('moment-tensors');
+    mt = mt ? mt[0] : {};
 
     _this.derivedMagnitudeEl.innerHTML = _this.formatter.magnitude(
         _this.model.get('derived-magnitude'),
@@ -294,10 +286,8 @@ _this.render = function () {
 
     _this.commentEl.innerHTML = _this.model.get('comment');
 
-    _this.momentEl.innerHTML = [
-      (mt['scalar-moment'].toExponential(3)).toUpperCase(),
-      ' N-m'
-    ].join('');
+    _this.momentEl.innerHTML = _this.formatter.exponential(
+        mt['scalar-moment'], 'N-m');
 
     _this.solutionTimeEl.innerHTML =
           _this.formatter.datetime(Date.parse(mt['derived-eventtime']));

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -29,13 +29,9 @@ var _DEFAULTS = {};
 *        A Magnitude Model object
 */
 var MagnitudeSummaryView = function (options) {
-
   var _this,
-      _initialize,
+      _initialize;
 
-      _collection,
-      _magnitudeCollectionView,
-      _magnitudeVersionsEl;
 
   options = Util.extend({model: MagnitudeModel()}, _DEFAULTS, options);
   _this = View(options);
@@ -44,7 +40,7 @@ var MagnitudeSummaryView = function (options) {
     var el;
 
     _this.formatter = options.formatter || Formatter({empty: ''});
-    _collection = options.collection || Collection([]);
+    _this.collection = options.collection || Collection([]);
 
     el = _this.el;
     el.innerHTML = [
@@ -60,13 +56,13 @@ var MagnitudeSummaryView = function (options) {
 
     _this.displayBeachBall();
 
-    _magnitudeVersionsEl = el.querySelector('.magnitude-versions');
-    _magnitudeCollectionView = MagnitudeCollectionTable({
-      el: _magnitudeVersionsEl,
-      collection: _collection,
+    _this.magnitudesEl = el.querySelector('.magnitude-versions');
+    _this.magnitudesTable = MagnitudeCollectionTable({
+      el: _this.magnitudesEl,
+      collection: _this.collection,
       model: _this.model
     });
-    _magnitudeCollectionView.render();
+    _this.magnitudesTable.render();
   };
 
 

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -22,33 +22,18 @@ var MagnitudeSummaryView = function (options) {
       _formatter,
       _magnitudeCollectionView,
       _magnitudeDetailsEl,
-      _magnitudeVersionsEl,
-      _tensor;
+      _magnitudeVersionsEl;
 
   options = Util.extend({}, _DEFAULTS, options);
   _this = View(options);
 
   _initialize = function (options) {
-    var el,
-        type;
+    var el;
 
     _formatter = Formatter({
       empty: ''
     });
     _collection = options.collection || Collection();
-
-    type = _this.getProperty('derived-magnitude-type');
-    type = (!type ? _this.getProperty('beachball-type') : '');
-    _tensor = Tensor({
-      'depth': _this.getProperty('derived-depth'),
-      'mrr': Number(_this.getProperty('tensor-mrr')),
-      'mtt': Number(_this.getProperty('tensor-mtt')),
-      'mpp': Number(_this.getProperty('tensor-mpp')),
-      'mrt': Number(_this.getProperty('tensor-mrt')),
-      'mrp': Number(_this.getProperty('tensor-mrp')),
-      'mtp': Number(_this.getProperty('tensor-mtp')),
-      'type': type,
-    });
 
     el = _this.el;
     el.innerHTML = '<div class="magnitude-summary-view">' +
@@ -281,6 +266,20 @@ var MagnitudeSummaryView = function (options) {
     return '';
   };
 
+  _this.getTensor = function () {
+    var tensor;
+
+    tensor = Tensor.fromStrikeDipRake(
+      Number(_this.getProperty('nodal-plane-1-strike')),
+      Number(_this.getProperty('nodal-plane-1-dip')),
+      Number(_this.getProperty('nodal-plane-1-rake') ||
+          _this.getProperty('nodal-plane-1-slip') || 0),
+      Number(_this.getProperty('scalar-moment') || Math.SQRT2)
+    );
+
+    return tensor;
+  };
+
   _this.displayBeachBall = function () {
     var beachBallView,
         el;
@@ -290,7 +289,7 @@ var MagnitudeSummaryView = function (options) {
       labelAxes: false,
       labelPlanes: false,
       size: 200,
-      tensor: _tensor
+      tensor: _this.getTensor()
     });
     beachBallView.render();
 

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -1,8 +1,9 @@
 'use strict';
 
 
-var BeachBallView = require('BeachBallView'),
+var BeachballView = require('BeachBallView'),
     Collection = require('mvc/Collection'),
+    EventModel = require('EventModel'),
     Formatter = require('Formatter'),
     MagnitudeCollectionTable = require('MagnitudeCollectionTable'),
     MagnitudeModel = require('MagnitudeModel'),
@@ -11,7 +12,9 @@ var BeachBallView = require('BeachBallView'),
     View = require('mvc/View');
 
 
-var _DEFAULTS = {};
+var _DEFAULTS = {
+  renderNow: false // should view render initially during construction
+};
 
 
 /**
@@ -30,216 +33,197 @@ var _DEFAULTS = {};
 */
 var MagnitudeSummaryView = function (options) {
   var _this,
-      _initialize;
+      _initialize,
+
+      _createViewScaffold;
 
 
   options = Util.extend({model: MagnitudeModel()}, _DEFAULTS, options);
   _this = View(options);
 
   _initialize = function (options) {
+    _this.formatter = options.formatter || Formatter({empty: ''});
+    _this.event = options.event || EventModel();
+    _this.magnitudes = Collection();
+
+    _createViewScaffold();
+
+    _this.magnitudesTable = MagnitudeCollectionTable({
+      el: _this.magnitudesEl,
+      collection: _this.magnitudes,
+      model: _this.model
+    });
+
+    if (options.renderNow) {
+      _this.render();
+    }
+  };
+
+
+  _createViewScaffold = function () {
     var el;
 
-    _this.formatter = options.formatter || Formatter({empty: ''});
-    _this.collection = options.collection || Collection([]);
-
     el = _this.el;
+
     el.innerHTML = [
       '<div class="magnitude-summary-view">',
         '<h3>Moment Summary</h3>',
-        '<table><tbody class="magnitude-details"></tbody></table>',
+        '<table>',
+          '<tbody class="magnitude-details">','<tr>',
+            '<th scope="row">Magnitude</th>',
+            '<td class="magnitude-derived-magnitude"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Observations</th>',
+            '<td class="magnitude-observations"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Source</th>',
+            '<td class="magnitude-source"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Internal</th>',
+            '<td class="magnitude-is-internal"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Preferred For Type</th>',
+            '<td class="magnitude-is-preferred"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Publishable</th>',
+            '<td class="magnitude-is-publishable"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Associated By</th>',
+            '<td class="magnitude-associated-by"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Comment</th>',
+            '<td class="magnitude-comment"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Moment</th>',
+            '<td class="magnitude-moment"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Solution Time</th>',
+            '<td class="magnitude-solution-time"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Solution Location</th>',
+            '<td class="magnitude-solution-location"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Solution Depth</th>',
+            '<td class="magnitude-solution-depth"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Solution Method</th>',
+            '<td class="magnitude-solution-method"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Fit</th>',
+            '<td class="magnitude-fit"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Variance Reduction</th>',
+            '<td class="magnitude-variance-reduction"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Percent Double Couple</th>',
+            '<td class="magnitude-percent-double-couple"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Focal Mechanism</th>',
+            '<td class="magnitude-beachball"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Nodal Plane 1</th>',
+            '<td class="magnitude-nodal-plane-1"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Nodal Plane 2</th>',
+            '<td class="magnitude-nodal-plane-2"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Percent CLVD</th>',
+            '<td class="magnitude-percent-clvd"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Source Time Decay</th>',
+            '<td class="magnitude-sourcetime-decay"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Source Time Duration</th>',
+            '<td class="magnitude-sourcetime-duration"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Source Time Rise</th>',
+            '<td class="magnitude-sourcetime-risetime"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Input Source</th>',
+            '<td class="magnitude-input-source"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Gap</th>',
+            '<td class="magnitude-azimuthal-gap"></td>',
+          '</tr>',
+          '<tr>',
+            '<th scope="row">Condition #</th>',
+            '<td class="magnitude-condition"></td>',
+          '</tr>',
+          '</tbody>',
+        '</table>',
         '<div class="magnitude-versions"></div>',
       '</div>'
     ].join('');
 
-    _this.dataTableEl = el.querySelector('.magnitude-details');
-    _this.dataTableEl.innerHTML = _this.render();
-
-    _this.displayBeachBall();
+    _this.derivedMagnitudeEl = el.querySelector('.magnitude-derived-magnitude');
+    _this.observationsEl = el.querySelector('.magnitude-observations');
+    _this.sourceEl = el.querySelector('.magnitude-source');
+    _this.internalEl = el.querySelector('.magnitude-is-internal');
+    _this.preferredEl = el.querySelector('.magnitude-is-preferred');
+    _this.publishableEl = el.querySelector('.magnitude-is-publishable');
+    _this.associatedByEl = el.querySelector('.magnitude-associated-by');
+    _this.commentEl = el.querySelector('.magnitude-comment');
+    _this.momentEl = el.querySelector('.magnitude-moment');
+    _this.solutionTimeEl = el.querySelector('.magnitude-solution-time');
+    _this.solutionLocationEl = el.querySelector('.magnitude-solution-location');
+    _this.solutionDepthEl = el.querySelector('.magnitude-solution-depth');
+    _this.solutionMethodEl = el.querySelector('.magnitude-solution-method');
+    _this.fitEl = el.querySelector('.magnitude-fit');
+    _this.varianceEl = el.querySelector('.magnitude-variance-reduction');
+    _this.percentDcEl = el.querySelector('.magnitude-percent-double-couple');
+    _this.beachballEl = el.querySelector('.magnitude-beachball');
+    _this.np1El = el.querySelector('.magnitude-nodal-plane-1');
+    _this.np2El = el.querySelector('.magnitude-nodal-plane-2');
+    _this.clvdEl = el.querySelector('.magnitude-percent-clvd');
+    _this.decayEl = el.querySelector('.magnitude-sourcetime-decay');
+    _this.durationEl = el.querySelector('.magnitude-sourcetime-duration');
+    _this.riseEl = el.querySelector('.magnitude-sourcetime-risetime');
+    _this.inputSourceEl = el.querySelector('.magnitude-input-source');
+    _this.azimuthalGapEl = el.querySelector('.magnitude-azimuthal-gap');
+    _this.conditionEl = el.querySelector('.magnitude-condition');
 
     _this.magnitudesEl = el.querySelector('.magnitude-versions');
-    _this.magnitudesTable = MagnitudeCollectionTable({
-      el: _this.magnitudesEl,
-      collection: _this.collection,
-      model: _this.model
-    });
-    _this.magnitudesTable.render();
   };
 
-
-  _this.render = function () {
-    var markup,
-        mt;
-
-    // TODO, remove this
-    var TODO = '<b>TODO</b>';
-
-    mt = _this.model.get('moment-tensors')[0] || {};
-
-    markup = [
-      '<tr>',
-        '<th scope="row">Magnitude</th>',
-        '<td>',
-          _this.model.get('derived-magnitude'), ' ',
-          _this.model.get('derived-magnitude-type'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Observations</th>',
-        '<td>',
-          _this.model.get('num-stations-used'), ' ',
-          '(', _this.model.get('num-stations-associated'), ')',
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Source</th>',
-        '<td>',
-          _this.model.get('installation'), ' - ', _this.model.get('author'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Internal</th>',
-        '<td>',
-          _this.model.get('is-internal'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Preferred For Type</th>',
-        '<td>',
-          _this.model.get('is-preferred'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Publishable</th>',
-        '<td>',
-          _this.model.get('is-preferred'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Associated By</th>',
-        '<td>',
-          _this.model.get('associated-by-installation'), ' - ',
-          _this.model.get('associated-by'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Comment</th>',
-        '<td>', _this.model.get('comment'), '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Moment</th>',
-        '<td>', mt['scalar-moment'], '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Solution Time</th>',
-        '<td>',
-          _this.formatter.datetime(Date.parse(mt['derived-eventtime'])),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Solution Location</th>',
-        '<td>',
-          _this.formatter.location(mt['derived-latitude'],
-              mt['derived-longitude']),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Solution Depth</th>',
-        '<td>', _this.formatter.depth(mt['derived-depth'], 'km'), '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Solution Method</th>',
-        '<td>', TODO, '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Fit</th>',
-        '<td>', mt.fit, '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Variance Reduction</th>',
-        '<td>', mt['variance-reduction'], '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Percent Double Couple</th>',
-        '<td>',
-          _this.formatter.number(mt['percent-double-couple'] * 100, 0,
-              '', '%'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Focal Mechanism</th>',
-        '<td class="beach-ball-view"></td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Nodal Plane 1</th>',
-        '<td>',
-          'Strike: ', mt['nodal-plane-1-strike'], '&nbsp',
-          'Dip: ', mt['nodal-plane-1-dip'], '&nbsp',
-          'Rake: ', mt['nodal-plane-1-slip'],
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Nodal Plane 2</th>',
-        '<td>',
-          'Strike: ', mt['nodal-plane-2-strike'], '&nbsp',
-          'Dip: ', mt['nodal-plane-2-dip'], '&nbsp',
-          'Rake: ', mt['nodal-plane-2-slip'],
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Percent CLVD</th>',
-        '<td>',
-          _this.formatter.number((1 - mt['percent-double-couple']) * 100, 0,
-              '', '%'),
-        '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Source Time Decay</th>',
-        '<td>', mt['sourcetime-decaytime'], '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Source Time Duration</th>',
-        '<td>', mt['sourcetime-duration'], '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Source Time Rise</th>',
-        '<td>', mt['sourcetime-risetime'], '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Input Source</th>',
-        '<td>', TODO, '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Gap</th>',
-        '<td>', mt['azimuthal-gap'], '</td>',
-      '</tr>',
-      '<tr>',
-        '<th scope="row">Condition #</th>',
-        '<td>', mt.condition, '</td>',
-      '</tr>'
-    ].join('');
-
-    return markup;
-  };
-
-  _this.displayBeachBall = function () {
-    var beachBallView,
-        el;
-
-    beachBallView = BeachBallView({
-      fillColor: '#ccc',
-      labelAxes: false,
-      labelPlanes: false,
-      size: 200,
-      tensor: _this.getTensor()
-    });
-    beachBallView.render();
-
-    el = _this.el.querySelector('.beach-ball-view');
-    el.appendChild(beachBallView.el);
-  };
 
   _this.destroy = Util.compose(function () {
-    _this.formatter = null;
+    if (_this === null) {
+      return;
+    }
+
+    if (_this.magnitudesTable) {
+      _this.magnitudesTable.destroy();
+      _this.magnitudesTable = null;
+    }
+
+    if (_this.magnitudes) {
+      _this.magnitudes.destroy();
+      _this.magnitudes = null;
+    }
 
     _initialize = null;
     _this = null;
@@ -256,17 +240,134 @@ var MagnitudeSummaryView = function (options) {
   };
 
   _this.getTensor = function () {
-    var tensor;
+    var mt,
+        tensor;
 
-    tensor = Tensor.fromStrikeDipRake(
-      Number(_this.getProperty('nodal-plane-1-strike')),
-      Number(_this.getProperty('nodal-plane-1-dip')),
-      Number(_this.getProperty('nodal-plane-1-rake') ||
-          _this.getProperty('nodal-plane-1-slip') || 0),
-      Number(_this.getProperty('scalar-moment') || Math.SQRT2)
-    );
+    mt = _this.model.get('moment-tensors')[0] || {};
+
+    tensor = Tensor({
+      mtt: mt['tensor-mtt'],
+      mpp: mt['tensor-mpp'],
+      mrr: mt['tensor-mrr'],
+      mrt: mt['tensor-mrt'],
+      mrp: mt['tensor-mrp'],
+      mtp: mt['tensor-mtp']
+    });
 
     return tensor;
+  };
+
+_this.render = function () {
+    var markup,
+        mt;
+
+    // TODO, remove this
+    var TODO = '<b>TODO</b>';
+
+    mt = _this.model.get('moment-tensors')[0] || {};
+
+    _this.derivedMagnitudeEl.innerHTML = [
+      _this.model.get('derived-magnitude'), ' ',
+      _this.model.get('derived-magnitude-type')
+    ].join('');
+
+    _this.observationsEl.innerHTML = [
+      _this.model.get('num-stations-used'), ' ',
+      '(', _this.model.get('num-stations-associated'), ')'
+    ].join('');
+
+    _this.sourceEl.innerHTML = [
+      _this.model.get('installation'), ' - ', _this.model.get('author')
+    ].join('');
+
+    _this.internalEl.innerHTML = _this.model.get('is-internal');
+    _this.preferredEl.innerHTML = _this.model.get('is-preferred');
+    _this.publishableEl.innerHTML = _this.model.get('is-preferred');
+
+    _this.associatedByEl.innerHTML = [
+      _this.model.get('associated-by-installation'), ' - ',
+      _this.model.get('associated-by')
+    ].join('');
+
+    _this.commentEl.innerHTML = _this.model.get('comment');
+
+
+    _this.momentEl.innerHTML = [
+      (mt['scalar-moment'].toExponential(3)).toUpperCase(),
+      ' N-m'
+    ].join('');
+
+    _this.solutionTimeEl.innerHTML =
+          _this.formatter.datetime(Date.parse(mt['derived-eventtime']));
+
+    _this.solutionLocationEl.innerHTML = _this.formatter.location(
+        mt['derived-latitude'], mt['derived-longitude']);
+    _this.solutionDepthEl.innerHTML =
+        _this.formatter.depth(mt['derived-depth'], 'km');
+
+    _this.solutionMethodEl.innerHTML = TODO;
+    _this.fitEl.innerHTML = mt.fit;
+    _this.varianceEl.innerHTML = mt['variance-reduction'];
+    _this.percentDcEl.innerHTML = _this.formatter.number(
+        mt['percent-double-couple'] * 100, 0, '', '%');
+
+    _this.np1El.innerHTML = [
+      'Strike: ', mt['nodal-plane-1-strike'], '&nbsp',
+      'Dip: ', mt['nodal-plane-1-dip'], '&nbsp',
+      'Rake: ', mt['nodal-plane-1-slip']
+    ].join('');
+
+    _this.np2El.innerHTML = [
+      'Strike: ', mt['nodal-plane-2-strike'], '&nbsp',
+      'Dip: ', mt['nodal-plane-2-dip'], '&nbsp',
+      'Rake: ', mt['nodal-plane-2-slip']
+    ].join('');
+
+    _this.clvdEl.innerHTML = _this.formatter.number(
+        (1 - mt['percent-double-couple']) * 100, 0, '', '%');
+
+    _this.decayEl.innerHTML = mt['sourcetime-decaytime'];
+    _this.durationEl.innerHTML = mt['sourcetime-duration'];
+    _this.riseEl.innerHTML = mt['sourcetime-risetime'];
+
+    _this.inputSourceEl.innerHTML = TODO;
+    _this.azimuthalGapEl.innerHTML = mt['azimuthal-gap'];
+    _this.conditionEl.innerHTML = mt.condition;
+
+    _this.renderBeachball();
+    _this.renderMagnitudeTable();
+
+    return markup;
+  };
+
+  _this.renderBeachball = function () {
+    var beachballView;
+
+    beachballView = BeachballView({
+      fillColor: '#ccc',
+      labelAxes: false,
+      labelPlanes: false,
+      size: 200,
+      tensor: _this.getTensor()
+    });
+
+    beachballView.render();
+    _this.beachballEl.appendChild(beachballView.el);
+
+    beachballView.destroy();
+  };
+
+  _this.renderMagnitudeTable = function () {
+    var type,
+        magnitudes;
+
+    type = _this.model.get('derived-magnitude-type');
+    magnitudes = _this.event.get('magnitudes').filter(function (magnitude) {
+      return type === magnitude.type;
+    });
+
+    // resetting the collection will cause the view to render
+    _this.magnitudes.reset(magnitudes);
   };
 
 

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -283,9 +283,9 @@ _this.render = function () {
     _this.internalEl.innerHTML = _this.formatter.boolean(
         _this.model.get('is-internal'));
     _this.preferredEl.innerHTML = _this.formatter.boolean(
-        _this.model.get('is-preferred'));
+        _this.model.get('is-preferred-for-type'));
     _this.publishableEl.innerHTML = _this.formatter.boolean(
-        _this.model.get('is-preferred'));
+        _this.model.get('is-publishable'));
 
     _this.associatedByEl.innerHTML = [
       _this.model.get('associated-by-installation'), ' - ',

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -160,111 +160,111 @@ var MagnitudeSummaryView = function (options) {
 
     markup =
       '<tr>' +
-        '<td>Magnitude</td>' +
+        '<th scope="row">Magnitude</th>' +
         '<td>' + magnitude + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Observations</td>' +
+        '<th scope="row">Observations</th>' +
         '<td>' + observations + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Source</td>' +
+        '<th scope="row">Source</th>' +
         '<td>' + source + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Internal</td>' +
+        '<th scope="row">Internal</th>' +
         '<td>' + isInternal + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Preferred For Type</td>' +
+        '<th scope="row">Preferred For Type</th>' +
         '<td>' + isPreferred + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Publishable</td>' +
+        '<th scope="row">Publishable</th>' +
         '<td>' + isPublishable + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Associated By</td>' +
+        '<th scope="row">Associated By</th>' +
         '<td>' + associatedBy + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Comment</td>' +
+        '<th scope="row">Comment</th>' +
         '<td>' + comment + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Moment</td>' +
+        '<th scope="row">Moment</th>' +
         '<td>' + moment + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Solution Time</td>' +
+        '<th scope="row">Solution Time</th>' +
         '<td>' + _formatter.datetime(Date.parse(time)) + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Solution Location</td>' +
+        '<th scope="row">Solution Location</th>' +
         '<td>' + _formatter.location(latitude, longitude) + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Solution Depth</td>' +
+        '<th scope="row">Solution Depth</th>' +
         '<td>' + _formatter.distance(depth, 'km') + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Solution Method</td>' +
+        '<th scope="row">Solution Method</th>' +
         '<td>' + value + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Fit</td>' +
+        '<th scope="row">Fit</th>' +
         '<td>' + fit + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Variance Reduction</td>' +
+        '<th scope="row">Variance Reduction</th>' +
         '<td>' + varianceReduction + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Percent Double Couple</td>' +
+        '<th scope="row">Percent Double Couple</th>' +
         '<td>' +
           _formatter.number(percentDoubleCouple * 100, 0, '', '%') +
         '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Focal Mechanism</td>' +
+        '<th scope="row">Focal Mechanism</th>' +
         '<td class="beach-ball-view"></td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Nodal Plane 1</td>' +
+        '<th scope="row">Nodal Plane 1</th>' +
         '<td>' + nodalPlane1 + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Nodal Plane 2</td>' +
+        '<th scope="row">Nodal Plane 2</th>' +
         '<td>' + nodalPlane2 + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Percent CLVD</td>' +
+        '<th scope="row">Percent CLVD</th>' +
         '<td>' +
           _formatter.number((1 - percentDoubleCouple) * 100, 0, '', '%') +
         '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Source Time Decay</td>' +
+        '<th scope="row">Source Time Decay</th>' +
         '<td>' + sourceTimeDecay + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Source Time Duration</td>' +
+        '<th scope="row">Source Time Duration</th>' +
         '<td>' + sourceTimeDuration + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Source Time Rise</td>' +
+        '<th scope="row">Source Time Rise</th>' +
         '<td>' + sourceTimeRise + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Input Source</td>' +
+        '<th scope="row">Input Source</th>' +
         '<td>' + inputSource + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Gap</td>' +
+        '<th scope="row">Gap</th>' +
         '<td>' + azimuthalGap + '</td>' +
       '</tr>' +
       '<tr>' +
-        '<td>Condition #</td>' +
+        '<th scope="row">Condition #</th>' +
         '<td>' + condition + '</td>' +
       '</tr>';
 

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -4,7 +4,7 @@
 var BeachBallView = require('BeachBallView'),
     Collection = require('mvc/Collection'),
     Formatter = require('Formatter'),
-    MagnitudeCollectionView = require('MagnitudeCollectionView'),
+    MagnitudeCollectionTable = require('MagnitudeCollectionTable'),
     Model = require('mvc/Model'),
     Tensor = require('Tensor'),
     Util = require('util/Util'),
@@ -73,7 +73,7 @@ var MagnitudeSummaryView = function (options) {
     _this.displayBeachBall();
 
     _magnitudeVersionsEl = el.querySelector('.magnitude-versions');
-    _magnitudeCollectionView = MagnitudeCollectionView({
+    _magnitudeCollectionView = MagnitudeCollectionTable({
       el: _magnitudeVersionsEl,
       collection: _collection,
       model: _this.model

--- a/src/htdocs/js/MagnitudeSummaryView.js
+++ b/src/htdocs/js/MagnitudeSummaryView.js
@@ -5,7 +5,7 @@ var BeachBallView = require('BeachBallView'),
     Collection = require('mvc/Collection'),
     Formatter = require('Formatter'),
     MagnitudeCollectionTable = require('MagnitudeCollectionTable'),
-    Model = require('mvc/Model'),
+    MagnitudeModel = require('MagnitudeModel'),
     Tensor = require('Tensor'),
     Util = require('util/Util'),
     View = require('mvc/View');
@@ -34,22 +34,17 @@ var MagnitudeSummaryView = function (options) {
       _initialize,
 
       _collection,
-      _ev,
-      _formatter,
       _magnitudeCollectionView,
       _magnitudeVersionsEl;
 
-  options = Util.extend({}, _DEFAULTS, options);
+  options = Util.extend({model: MagnitudeModel()}, _DEFAULTS, options);
   _this = View(options);
 
   _initialize = function (options) {
     var el;
 
-    _formatter = Formatter({
-      empty: ''
-    });
-    _collection = options.collection || Collection();
-    _ev = options.ev || Model();
+    _this.formatter = options.formatter || Formatter({empty: ''});
+    _collection = options.collection || Collection([]);
 
     el = _this.el;
     el.innerHTML = [
@@ -61,7 +56,7 @@ var MagnitudeSummaryView = function (options) {
     ].join('');
 
     _this.dataTableEl = el.querySelector('.magnitude-details');
-    _this.dataTableEl.innerHTML = _this.buildMagnitudeDetailsMarkup();
+    _this.dataTableEl.innerHTML = _this.render();
 
     _this.displayBeachBall();
 
@@ -72,204 +67,187 @@ var MagnitudeSummaryView = function (options) {
       model: _this.model
     });
     _magnitudeCollectionView.render();
-
-    _this.timerCountUp(_ev.get('eventtime'));
   };
 
-  _this.buildMagnitudeDetailsMarkup = function () {
-    var associatedBy,
-        azimuthalGap,
-        comment,
-        condition,
-        depth,
-        eventDepth,
-        eventGeometry,
-        eventLatitude,
-        eventLongitude,
-        eventMagnitude,
-        eventRegion,
-        eventTime,
-        fit,
-        inputSource,
-        isInternal,
-        isPreferred,
-        isPublishable,
-        latitude,
-        longitude,
-        magnitude,
-        markup,
-        moment,
-        nodalPlane1,
-        nodalPlane2,
-        observations,
-        percentDoubleCouple,
-        source,
-        sourceTimeDecay,
-        sourceTimeDuration,
-        sourceTimeRise,
-        time,
-        varianceReduction;
 
-    // Event Details
-    eventGeometry = _ev.get('geometry');
-    if (eventGeometry) {
-      eventDepth = _ev.get('geometry').coordinates[2];
-      eventLatitude = _ev.get('geometry').coordinates[0];
-      eventLongitude = _ev.get('geometry').coordinates[1];
-    }
-    eventMagnitude = _ev.get('magnitude') + ' ' + _ev.get('magnitudeType');
-    eventRegion = _ev.get('title');
-    eventTime = _ev.get('eventtime');
-
-    // Magnitude Details
-    associatedBy = _this.getProperty('associated-by-installation') + ' - ' +
-        _this.getProperty('associated-by');
-    azimuthalGap = _this.getProperty('azimuthal-gap');
-    comment = _this.getProperty('comment');
-    condition = _this.getProperty('condition');
-    depth = _this.getProperty('derived-depth');
-    fit = _this.getProperty('fit');
-    inputSource = _this.getProperty('inputSource');
-    isInternal = _this.getProperty('is-internal');
-    isPreferred = _this.getProperty('is-preferred-for-type');
-    isPublishable = _this.getProperty('is-publishable');
-    latitude = _this.getProperty('derived-latitude');
-    longitude = _this.getProperty('derived-longitude');
-    magnitude = _this.getProperty('derived-magnitude') + ' ' +
-        _this.getProperty('derived-magnitude-type');
-    moment = _this.getProperty('scalar-moment');
-    observations = _this.getProperty('num-stations-used') + ' (' +
-        _this.getProperty('num-stations-associated') + ')';
-    percentDoubleCouple = _this.getProperty('percent-double-couple');
-    source = _this.getProperty('installation') + ' - ' +
-        _this.getProperty('author');
-    sourceTimeDecay = _this.getProperty('sourcetime-decaytime');
-    sourceTimeDuration = _this.getProperty('sourcetime-duration');
-    sourceTimeRise = _this.getProperty('sourcetime-risetime');
-    time = _this.getProperty('derived-eventtime');
-    varianceReduction = _this.getProperty('variance-reduction');
-    nodalPlane1 = 'Strike: ' + _this.getProperty('nodal-plane-1-strike') +
-        '&nbsp;&nbsp; Dip: ' + _this.getProperty('nodal-plane-1-dip') +
-        '&nbsp;&nbsp; Rake: ' + _this.getProperty('nodal-plane-1-slip');
-    nodalPlane2 = 'Strike: ' + _this.getProperty('nodal-plane-2-strike') +
-        '&nbsp;&nbsp; Dip: ' + _this.getProperty('nodal-plane-2-dip') +
-        '&nbsp;&nbsp; Rake: ' + _this.getProperty('nodal-plane-2-slip');
+  _this.render = function () {
+    var markup,
+        mt;
 
     // TODO, remove this
-    var value = '<b>TODO</b>';
+    var TODO = '<b>TODO</b>';
 
-    markup =
-      '<tr>' +
-        '<th scope="row">Magnitude</th>' +
-        '<td>' + magnitude + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Observations</th>' +
-        '<td>' + observations + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Source</th>' +
-        '<td>' + source + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Internal</th>' +
-        '<td>' + isInternal + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Preferred For Type</th>' +
-        '<td>' + isPreferred + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Publishable</th>' +
-        '<td>' + isPublishable + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Associated By</th>' +
-        '<td>' + associatedBy + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Comment</th>' +
-        '<td>' + comment + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Moment</th>' +
-        '<td>' + moment + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Solution Time</th>' +
-        '<td>' + _formatter.datetime(Date.parse(time)) + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Solution Location</th>' +
-        '<td>' + _formatter.location(latitude, longitude) + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Solution Depth</th>' +
-        '<td>' + _formatter.distance(depth, 'km') + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Solution Method</th>' +
-        '<td>' + value + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Fit</th>' +
-        '<td>' + fit + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Variance Reduction</th>' +
-        '<td>' + varianceReduction + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Percent Double Couple</th>' +
-        '<td>' +
-          _formatter.number(percentDoubleCouple * 100, 0, '', '%') +
-        '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Focal Mechanism</th>' +
-        '<td class="beach-ball-view"></td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Nodal Plane 1</th>' +
-        '<td>' + nodalPlane1 + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Nodal Plane 2</th>' +
-        '<td>' + nodalPlane2 + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Percent CLVD</th>' +
-        '<td>' +
-          _formatter.number((1 - percentDoubleCouple) * 100, 0, '', '%') +
-        '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Source Time Decay</th>' +
-        '<td>' + sourceTimeDecay + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Source Time Duration</th>' +
-        '<td>' + sourceTimeDuration + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Source Time Rise</th>' +
-        '<td>' + sourceTimeRise + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Input Source</th>' +
-        '<td>' + inputSource + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Gap</th>' +
-        '<td>' + azimuthalGap + '</td>' +
-      '</tr>' +
-      '<tr>' +
-        '<th scope="row">Condition #</th>' +
-        '<td>' + condition + '</td>' +
-      '</tr>';
+    mt = _this.model.get('moment-tensors')[0] || {};
+
+    markup = [
+      '<tr>',
+        '<th scope="row">Magnitude</th>',
+        '<td>',
+          _this.model.get('derived-magnitude'), ' ',
+          _this.model.get('derived-magnitude-type'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Observations</th>',
+        '<td>',
+          _this.model.get('num-stations-used'), ' ',
+          '(', _this.model.get('num-stations-associated'), ')',
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Source</th>',
+        '<td>',
+          _this.model.get('installation'), ' - ', _this.model.get('author'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Internal</th>',
+        '<td>',
+          _this.model.get('is-internal'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Preferred For Type</th>',
+        '<td>',
+          _this.model.get('is-preferred'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Publishable</th>',
+        '<td>',
+          _this.model.get('is-preferred'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Associated By</th>',
+        '<td>',
+          _this.model.get('associated-by-installation'), ' - ',
+          _this.model.get('associated-by'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Comment</th>',
+        '<td>', _this.model.get('comment'), '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Moment</th>',
+        '<td>', mt['scalar-moment'], '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Solution Time</th>',
+        '<td>',
+          _this.formatter.datetime(Date.parse(mt['derived-eventtime'])),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Solution Location</th>',
+        '<td>',
+          _this.formatter.location(mt['derived-latitude'],
+              mt['derived-longitude']),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Solution Depth</th>',
+        '<td>', _this.formatter.depth(mt['derived-depth'], 'km'), '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Solution Method</th>',
+        '<td>', TODO, '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Fit</th>',
+        '<td>', mt.fit, '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Variance Reduction</th>',
+        '<td>', mt['variance-reduction'], '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Percent Double Couple</th>',
+        '<td>',
+          _this.formatter.number(mt['percent-double-couple'] * 100, 0,
+              '', '%'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Focal Mechanism</th>',
+        '<td class="beach-ball-view"></td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Nodal Plane 1</th>',
+        '<td>',
+          'Strike: ', mt['nodal-plane-1-strike'], '&nbsp',
+          'Dip: ', mt['nodal-plane-1-dip'], '&nbsp',
+          'Rake: ', mt['nodal-plane-1-slip'],
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Nodal Plane 2</th>',
+        '<td>',
+          'Strike: ', mt['nodal-plane-2-strike'], '&nbsp',
+          'Dip: ', mt['nodal-plane-2-dip'], '&nbsp',
+          'Rake: ', mt['nodal-plane-2-slip'],
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Percent CLVD</th>',
+        '<td>',
+          _this.formatter.number((1 - mt['percent-double-couple']) * 100, 0,
+              '', '%'),
+        '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Source Time Decay</th>',
+        '<td>', mt['sourcetime-decaytime'], '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Source Time Duration</th>',
+        '<td>', mt['sourcetime-duration'], '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Source Time Rise</th>',
+        '<td>', mt['sourcetime-risetime'], '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Input Source</th>',
+        '<td>', TODO, '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Gap</th>',
+        '<td>', mt['azimuthal-gap'], '</td>',
+      '</tr>',
+      '<tr>',
+        '<th scope="row">Condition #</th>',
+        '<td>', mt.condition, '</td>',
+      '</tr>'
+    ].join('');
 
     return markup;
   };
+
+  _this.displayBeachBall = function () {
+    var beachBallView,
+        el;
+
+    beachBallView = BeachBallView({
+      fillColor: '#ccc',
+      labelAxes: false,
+      labelPlanes: false,
+      size: 200,
+      tensor: _this.getTensor()
+    });
+    beachBallView.render();
+
+    el = _this.el.querySelector('.beach-ball-view');
+    el.appendChild(beachBallView.el);
+  };
+
+  _this.destroy = Util.compose(function () {
+    _this.formatter = null;
+
+    _initialize = null;
+    _this = null;
+  }, _this.destroy);
 
   _this.getProperty = function (key) {
     var properties;
@@ -294,73 +272,6 @@ var MagnitudeSummaryView = function (options) {
 
     return tensor;
   };
-
-  _this.displayBeachBall = function () {
-    var beachBallView,
-        el;
-
-    beachBallView = BeachBallView({
-      fillColor: '#ccc',
-      labelAxes: false,
-      labelPlanes: false,
-      size: 200,
-      tensor: _this.getTensor()
-    });
-    beachBallView.render();
-
-    el = _this.el.querySelector('.beach-ball-view');
-    el.appendChild(beachBallView.el);
-  };
-
-  _this.timerCountUp = function (datetime) {
-    var current,
-        el,
-        milliseconds,
-        elapsed;
-
-    el = _this.el.querySelector('.timer-count-up');
-
-    try {
-      current = new Date().getTime();
-      milliseconds = Date.parse(datetime);
-      elapsed = Math.floor((current - milliseconds) / 1000);
-    } catch (e) {
-      el.innerHTML = '';
-      return;
-    }
-
-    window.setInterval(function () {
-      var clock,
-          days,
-          hrs,
-          mins,
-          secs,
-          weeks;
-
-      elapsed++;
-      weeks = Math.floor(elapsed/604800);
-      days = Math.floor(elapsed/86400) % 7;
-      hrs = Math.floor(elapsed/3600) % 24;
-      mins = Math.floor(elapsed/60) % 60;
-      secs = elapsed % 60;
-
-      clock =
-          (weeks ? weeks + ' weeks, ' : '') +
-          (days ? days + ' days, ' : '') +
-          (hrs ? hrs + ':' : '') +
-          (mins ? mins + ':' : '') +
-          (secs < 10 ? '0' + secs : secs);
-
-      el.innerHTML = clock;
-    }, 1000);
-  };
-
-  _this.destroy = Util.compose(function () {
-    _formatter = null;
-
-    _initialize = null;
-    _this = null;
-  }, _this.destroy);
 
 
   _initialize(options);

--- a/src/htdocs/js/Tensor.js
+++ b/src/htdocs/js/Tensor.js
@@ -1,0 +1,325 @@
+'use strict';
+
+var Matrix = require('math/Matrix');
+
+
+var _BEACHBALL_METHODS,
+    _D2R,
+    _R2D,
+    __calculatePlane,
+    __fromProduct,
+    __fromStrikeDipRake,
+    __range,
+    __sortEigenvalues,
+    Tensor;
+
+
+_BEACHBALL_METHODS = {
+  'smi:ci.anss.org/momentTensor/TMTS': 'TMTS',
+  'smi:nc.anss.org/momentTensor/TMTS': 'TMTS',
+  'smi:nc.anss.org/momentTensor/TMTS-ISO': 'TMTS-ISO',
+  'smi:uu.anss.org/momentTensor/TDMT': 'TDMT'
+};
+
+_D2R = Math.PI / 180;
+_R2D = 180 / Math.PI;
+
+/**
+ * Calculate one nodal plane.
+ *
+ * Argument order matters, so getPlane(v1, v2) and getPlane(v2, v1)
+ * are different planes.
+ *
+ * @param v1 {Vector}
+ *     first vector.
+ * @param v2 {Vector}
+ *     second vector.
+ * @return {Object}
+ *     computed plane, defined as the properties strike, dip, and rake.
+ */
+__calculatePlane = function (v1, v2) {
+  v1 = v1.unit();
+  v2 = v2.unit();
+  // make sure first vector dips downward
+  if (v1.z() > 0) {
+    v1 = v1.multiply(-1);
+    v2 = v2.multiply(-1);
+  }
+  return {
+    strike: __range(Math.atan2(-v1.x(), v1.y()), 0, 2 * Math.PI) * _R2D,
+    dip: Math.acos(-v1.z()) * _R2D,
+    rake: Math.atan2(-v2.z(), v2.cross(v1).z()) * _R2D
+  };
+};
+
+/**
+ * Create a Tensor object from a Product object.
+ *
+ * @param product {Product}
+ *     a focal-mechanism or moment-tensor product.
+ */
+__fromProduct = function (product) {
+  var depth,
+      props,
+      type,
+      tensor;
+
+  tensor = null;
+  type = product.get('type');
+  props = product.get('properties') || {};
+
+  if (type === 'focal-mechanism') {
+    tensor = __fromStrikeDipRake(
+        Number(props['nodal-plane-1-strike']),
+        Number(props['nodal-plane-1-dip']),
+        Number(props['nodal-plane-1-rake'] || props['nodal-plane-1-slip'] || 0),
+        Number(props['scalar-moment'] || Math.SQRT2));
+  } else if (type === 'moment-tensor') {
+    tensor = Tensor({
+      mrr: Number(props['tensor-mrr']),
+      mtt: Number(props['tensor-mtt']),
+      mpp: Number(props['tensor-mpp']),
+      mrt: Number(props['tensor-mrt']),
+      mrp: Number(props['tensor-mrp']),
+      mtp: Number(props['tensor-mtp'])
+    });
+
+    depth = product.getProperty('derived-depth');
+    if (depth === null)  {
+      depth = product.getProperty('depth');
+    }
+
+    tensor.depth = depth;
+  }
+
+  if (tensor) {
+    type = product.getProperty('derived-magnitude-type');
+    if (!type) {
+      type = product.getProperty('beachball-type');
+      if (type && _BEACHBALL_METHODS.hasOwnProperty(type)) {
+        type = _BEACHBALL_METHODS[type];
+      }
+    }
+
+    if (type) {
+      tensor.type = type;
+    }
+  }
+
+  return tensor;
+};
+
+/**
+ * Create a Tensor from strike, dip, and rake of one nodal plane.
+ *
+ * @param strike {Number}
+ *        strike of nodal plane in degrees.
+ * @param dip {Number}
+ *        dip of nodal plane in degrees.
+ * @param rake {Number}
+ *        rake of nodal plane in degrees.
+ * @param moment {Number}
+ *        scale resulting matrix by this number.
+ * @return Tensor object.
+ */
+__fromStrikeDipRake = function(strike, dip, rake, moment) {
+  var c2d,
+      c2s,
+      cd,
+      cr,
+      cs,
+      d,
+      mxx,
+      mxy,
+      mxz,
+      myy,
+      myz,
+      mzz,
+      r,
+      s,
+      s2d,
+      s2s,
+      sd,
+      sr,
+      ss;
+
+  s = strike * _D2R;
+  ss = Math.sin(s);
+  cs = Math.cos(s);
+  s2s = Math.sin(2*s);
+  c2s = Math.cos(2*s);
+  d = dip * _D2R;
+  sd = Math.sin(d);
+  cd = Math.cos(d);
+  s2d = Math.sin(2*d);
+  c2d = Math.cos(2*d);
+  r = (rake % 90 !== 0 ? rake : rake + 1e-15) * _D2R;
+  sr = Math.sin(r);
+  cr = Math.cos(r);
+
+  // mtt
+  mxx = -1 * (sd * cr * s2s + s2d * sr * ss * ss);
+  // -mtp
+  mxy =      (sd * cr * c2s + s2d * sr * s2s * 0.5);
+  // mrt
+  mxz = -1 * (cd * cr * cs  + c2d * sr * ss);
+  // mpp
+  myy =      (sd * cr * s2s - s2d * sr * cs * cs);
+  // -mrp
+  myz = -1 * (cd * cr * ss  - c2d * sr * cs);
+  // mrr
+  mzz =      (s2d * sr);
+
+  return Tensor({
+    mrr:  mzz * moment,
+    mtt:  mxx * moment,
+    mpp:  myy * moment,
+    mtp: -mxy * moment,
+    mrp: -myz * moment,
+    mrt:  mxz * moment
+  });
+};
+
+/**
+ * Shift a number until it is in the specified range.
+ *
+ * Add or subtract the range size (max - min) until value is between.
+ *
+ * @param value {Number}
+ *        value to normalize.
+ * @param min {Number}
+ *        range minimum.
+ * @param max {Number}
+ *        range maximum.
+ * @return {Number} value in the range [min, max).
+ */
+__range = function (value, min, max) {
+  var span = max - min;
+  while (value < min) {
+    value += span;
+  }
+  while (value >= max) {
+    value -= span;
+  }
+  return value;
+};
+
+/**
+ * Sort eigen vectors in descending order by magnitude.
+ *
+ * @param v1 {Vector}
+ *     first vector.
+ * @param v2 {Vector}
+ *     second vector.
+ */
+__sortEigenvalues = function (v1, v2) {
+  var v1mag,
+      v2mag;
+  // largest value first
+  v1mag = v1.eigenvalue;
+  v2mag = v2.eigenvalue;
+  if (v1mag < v2mag) {
+    return 1;
+  } else if (v1mag > v2mag) {
+    return -1;
+  } else {
+    return 0;
+  }
+};
+
+/**
+ * Construct a new tensor.
+ *
+ * @param mtt {Number}
+ *        mtt value in N-m.
+ * @param mpp {Number}
+ *        mpp value in N-m.
+ * @param mrr {Number}
+ *        mrr value in N-m.
+ * @param mrt {Number}
+ *        mrt value in N-m.
+ * @param mrp {Number}
+ *        mrp value in N-m.
+ * @param mtp {Number}
+ *        mtp value in N-m.
+ */
+ Tensor = function (options) {
+  var _this,
+      _initialize;
+
+  _this = {};
+
+  _initialize = function (options) {
+    var eigen,
+        exponent,
+        l,
+        moment,
+        moment_log10,
+        mpp,
+        mrr,
+        mrt,
+        mrp,
+        mtp,
+        mtt,
+        n,
+        p,
+        t;
+
+    _this.mtt = mtt = options.mtt || options.mxx || 0;
+    _this.mpp = mpp = options.mpp || options.myy || 0;
+    _this.mrr = mrr = options.mrr || options.mzz || 0;
+    _this.mrt = mrt = options.mrt || options.mxz || 0;
+    _this.mrp = mrp = options.mrp || -options.myz || 0;
+    _this.mtp = mtp = options.mtp || -options.mxy || 0;
+    _this.units = 'N-m';
+
+    // calculate moment and derived values
+    _this.moment = moment = Math.sqrt(0.5 *
+        ( (mrr * mrr + mtt * mtt + mpp * mpp) +
+        2 * (mrt * mrt + mrp * mrp + mtp * mtp) ));
+    _this.moment_log10 = moment_log10 = Math.log(moment) / Math.LN10;
+    _this.exponent = exponent = parseInt(moment_log10, 10);
+    _this.scale = Math.pow(10, exponent);
+    _this.magnitude = (2/3) * (moment_log10 - 9.1);
+
+    // calculate principal axes
+    _this.matrix = Matrix([
+      mtt, -mtp, mrt,
+      -mtp, mpp, -mrp,
+      mrt, -mrp, mrr
+    ], 3, 3);
+    eigen = _this.matrix.jacobi();
+    eigen.sort(__sortEigenvalues);
+    _this.T = t = eigen[0];
+    _this.N = n = eigen[1];
+    _this.P = p = eigen[2];
+    _this.fCLVD = n.eigenvalue /
+        Math.max(Math.abs(t.eigenvalue), Math.abs(p.eigenvalue));
+    _this.percentDC = Math.abs(1 - Math.abs(_this.fCLVD) / 0.5);
+    _this.forceThrust = Math.pow(Math.sin(t.plunge()), 2);
+    _this.forceStrikeSlip = Math.pow(Math.sin(n.plunge()), 2);
+    _this.forceNormal = Math.pow(Math.sin(p.plunge()), 2);
+
+    // calculate nodal planes
+    // p = (n - l) / sqrt2
+    // t = (n + l) / sqrt2
+    l = t.subtract(p).unit();
+    n = t.add(p).unit();
+    _this.NP1 = __calculatePlane(l, n);
+    _this.NP2 = __calculatePlane(n, l);
+  };
+
+
+  _initialize(options);
+  options = null;
+  return _this;
+};
+
+
+// add static methods
+Tensor.calculatePlane = __calculatePlane;
+Tensor.fromProduct = __fromProduct;
+Tensor.fromStrikeDipRake = __fromStrikeDipRake;
+
+
+module.exports = Tensor;

--- a/test/spec/EventSummaryViewTest.js
+++ b/test/spec/EventSummaryViewTest.js
@@ -17,6 +17,10 @@ describe('EventSummaryView', function () {
       success: function (data) {
         model = EventModel.fromFeature(data);
         done();
+      },
+      error: function (e) {
+        console.log(e.stack);
+        done(e);
       }
     });
 

--- a/test/spec/MagnitudeSummaryViewTest.js
+++ b/test/spec/MagnitudeSummaryViewTest.js
@@ -1,0 +1,31 @@
+/* global chai, describe, it */
+'use strict';
+
+var MagnitudeSummaryView = require('MagnitudeSummaryView');
+
+
+var expect = chai.expect;
+
+
+describe('MagnitudeSummaryView', function () {
+
+  describe('constructor', function () {
+    it('is defined', function () {
+      expect(typeof MagnitudeSummaryView).to.equal('function');
+    });
+
+    it('can be instantiated', function () {
+      expect(MagnitudeSummaryView).to.not.throw(Error);
+    });
+  });
+
+  describe('destroy', function () {
+    it('can be destroyed', function () {
+      var view;
+
+      view = MagnitudeSummaryView();
+      expect(view.destroy).to.not.throw(Error);
+    });
+  });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,8 @@ require('./spec/FormatterTest');
 require('./spec/MagnitudeCollectionTableTest');
 require('./spec/MagnitudeTabViewTest');
 
+require('./spec/MagnitudeSummaryViewTest');
+
 
 if (window.mochaPhantomJS) {
   window.mochaPhantomJS.run();


### PR DESCRIPTION
fixes usgs/hydra-web-display#5
replaces usgs/hydra-web-display#17

Building from what Eddie did ...
- Refactored code to be more MVC View-like
- Filled in some missing gaps in the data
- Updated to use new EventModel and MagnitudeModel based on latest web service output formats.

This is functional to the point that the pull request can be merged, but the issue itself should be opened pending the following ToDos and Questions.

Still to do ...
- Tests
- Method comments
- Source organization
  - Should `BeachBallView` be here or some utility class. If unchanged from earthquake-eventpages, perhaps we should just pull in the dependency.
  - Maybe time to start using packages withing JS and CSS folders?

Questions for @mguy-usgs and @jpatton-USGS 
- Ignoring the template wrapper around the view, what do you think about the current visualization (attached)?
- I've formatted numbers to match the output in the screenshot from existing Hydra display. If you would like more or less precision that is displayed (or just no formatting), please let me know.
- Dates are formatted as ISO8601 for now. Do we need to switch to the Hydra format?
- Are all the units correct? Jeremy mentioned the data for moment is in N-m and not dyn-cm...
- Do you want nodal planes and axis labels on the focal mechanism plot?
- Can this summary re-designed at all? I'm thinking:
  - Magnitude section containing properties specific to the magnitude as a whole.
  - Moment tensor section containing properties specific to the preferred moment tensor (or even a tabbed list of all available moment tensors). This includes the beachball.
  - Other magnitudes section.
- Still missing some fields from the magnitude data structure...
  - `is-publishable`, `comment`, `input-source`, `solution-method`
  - How should we handle these in the interim?



![magnitude-summary](https://cloud.githubusercontent.com/assets/1726751/17231581/14e35cc0-54e0-11e6-8ebd-6d9cc08e382c.png)